### PR TITLE
refactor/#68 noise entity에서 review 분리

### DIFF
--- a/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/NoiseApiController.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/NoiseApiController.java
@@ -41,7 +41,7 @@ public class NoiseApiController {
 			- Description : 이 API는 해당 소음 데이터를 조회합니다.
 		""")
 	@ApiResponse(responseCode = "200")
-	@GetMapping("/noise/{noiseId}")
+	@GetMapping("/{noiseId}")
 	public ResponseEntity<NoiseSummaryResponse> getUserNoiseDetail(
 		@Parameter(description = "조회할 noise 데이터의 ID", example = "10", required = true)
 		@PathVariable String noiseId

--- a/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/response/NoisePersistResponse.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/response/NoisePersistResponse.java
@@ -12,7 +12,7 @@ public record NoisePersistResponse(
 	String id
 ) {
 	public static NoisePersistResponse from(Noise noise){
-		return builder()
+		return NoisePersistResponse.builder()
 			.id(noise.extractUuid())
 			.build();
 	}

--- a/soridam-api/src/main/java/sorisoop/soridam/api/review/ReviewApiController.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/review/ReviewApiController.java
@@ -1,0 +1,62 @@
+package sorisoop.soridam.api.review;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import sorisoop.soridam.api.review.application.ReviewFacade;
+import sorisoop.soridam.api.review.presentation.request.ReviewCreateRequest;
+import sorisoop.soridam.api.review.presentation.request.ReviewUpdateRequest;
+import sorisoop.soridam.api.review.presentation.response.ReviewPersistResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reviews")
+@Tag(name = "Review", description = "리뷰 API")
+public class ReviewApiController {
+	private final ReviewFacade reviewFacade;
+
+	@Operation(summary = "리뷰 생성 API", description = "리뷰를 생성합니다.")
+	@ApiResponse(responseCode = "201", description = "리뷰 생성 성공")
+	@PostMapping
+	public ResponseEntity<ReviewPersistResponse> createReview(
+		@Valid @RequestBody ReviewCreateRequest request) {
+		ReviewPersistResponse response = reviewFacade.create(request);
+		return ResponseEntity.status(CREATED).body(response);
+	}
+
+	@Operation(summary = "리뷰 업데이트 API", description = "리뷰를 업데이트합니다.")
+	@ApiResponse(responseCode = "200", description = "리뷰 업데이트 성공")
+	@PutMapping("/{reviewId}")
+	public ResponseEntity<Void> updateReview(
+		@Parameter(description = "리뷰 ID", example = "123", required = true)
+		@PathVariable String reviewId,
+		@Valid @RequestBody ReviewUpdateRequest request) {
+		reviewFacade.update(reviewId, request);
+		return ResponseEntity.ok().build();
+	}
+
+	@Operation(summary = "리뷰 삭제 API", description = "리뷰를 삭제합니다.")
+	@ApiResponse(responseCode = "204", description = "리뷰 삭제 성공")
+	@DeleteMapping("/{reviewId}")
+	public ResponseEntity<Void> deleteReview(
+		@Parameter(description = "리뷰 ID", example = "123", required = true)
+		@PathVariable String reviewId) {
+		reviewFacade.delete(reviewId);
+		return ResponseEntity.noContent().build();
+	}
+}
+

--- a/soridam-api/src/main/java/sorisoop/soridam/api/review/application/ReviewFacade.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/review/application/ReviewFacade.java
@@ -1,0 +1,45 @@
+package sorisoop.soridam.api.review.application;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import sorisoop.soridam.api.review.presentation.request.ReviewCreateRequest;
+import sorisoop.soridam.api.review.presentation.request.ReviewUpdateRequest;
+import sorisoop.soridam.api.review.presentation.response.ReviewPersistResponse;
+import sorisoop.soridam.domain.review.application.ReviewCommandService;
+import sorisoop.soridam.domain.review.application.ReviewQueryService;
+import sorisoop.soridam.domain.review.domain.Review;
+import sorisoop.soridam.domain.user.application.UserQueryService;
+import sorisoop.soridam.domain.user.domain.User;
+
+@Component
+@RequiredArgsConstructor
+public class ReviewFacade {
+	private final ReviewCommandService reviewCommandService;
+	private final ReviewQueryService reviewQueryService;
+	private final UserQueryService userQueryService;
+
+	public ReviewPersistResponse create(ReviewCreateRequest request) {
+		User author = userQueryService.me();
+
+		Review review = reviewCommandService.create(
+			request.targetId(),
+			request.reviewType(),
+			author.getId(),
+			request.content(),
+			request.rating()
+		);
+
+		return ReviewPersistResponse.from(review);
+	}
+
+	public void update(String reviewId, ReviewUpdateRequest request) {
+		Review review = reviewQueryService.getById(reviewId);
+		reviewCommandService.update(review, request.content(), request.rating());
+	}
+
+	public void delete(String reviewId) {
+		User user = userQueryService.me();
+		reviewCommandService.delete(user, reviewId);
+	}
+}

--- a/soridam-api/src/main/java/sorisoop/soridam/api/review/application/ReviewFacade.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/review/application/ReviewFacade.java
@@ -34,12 +34,14 @@ public class ReviewFacade {
 	}
 
 	public void update(String reviewId, ReviewUpdateRequest request) {
+		User user = userQueryService.me();
 		Review review = reviewQueryService.getById(reviewId);
-		reviewCommandService.update(review, request.content(), request.rating());
+		reviewCommandService.update(user, review, request.content(), request.rating());
 	}
 
 	public void delete(String reviewId) {
 		User user = userQueryService.me();
-		reviewCommandService.delete(user, reviewId);
+		Review review = reviewQueryService.getById(reviewId);
+		reviewCommandService.delete(user, review);
 	}
 }

--- a/soridam-api/src/main/java/sorisoop/soridam/api/review/presentation/request/ReviewCreateRequest.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/review/presentation/request/ReviewCreateRequest.java
@@ -1,0 +1,34 @@
+package sorisoop.soridam.api.review.presentation.request;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.math.BigDecimal;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import sorisoop.soridam.globalutil.uuid.UuidPrefix;
+
+@Builder
+public record ReviewCreateRequest(
+	@Schema(description = "게시글 ID", example = "uuid", requiredMode = REQUIRED)
+	@NotBlank
+	String targetId,
+
+	@Schema(description = "게시글 타입", example = "NOISE", requiredMode = REQUIRED)
+	@NotBlank
+	UuidPrefix reviewType,
+
+	@Schema(description = "작성 내용", example = "content", requiredMode = REQUIRED)
+	String content,
+
+	@Schema(description = "평점", example = "5.0", requiredMode = REQUIRED)
+	@NotNull
+	@DecimalMin(value = "0.0")
+	@DecimalMax(value = "5.0")
+	BigDecimal rating
+) {
+}

--- a/soridam-api/src/main/java/sorisoop/soridam/api/review/presentation/request/ReviewCreateRequest.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/review/presentation/request/ReviewCreateRequest.java
@@ -19,7 +19,7 @@ public record ReviewCreateRequest(
 	String targetId,
 
 	@Schema(description = "게시글 타입", example = "NOISE", requiredMode = REQUIRED)
-	@NotBlank
+	@NotNull
 	UuidPrefix reviewType,
 
 	@Schema(description = "작성 내용", example = "content", requiredMode = REQUIRED)

--- a/soridam-api/src/main/java/sorisoop/soridam/api/review/presentation/request/ReviewUpdateRequest.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/review/presentation/request/ReviewUpdateRequest.java
@@ -1,0 +1,22 @@
+package sorisoop.soridam.api.review.presentation.request;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.math.BigDecimal;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+
+public record ReviewUpdateRequest(
+	@Schema(description = "수정한 작성 내용", example = "content", requiredMode = REQUIRED)
+	String content,
+
+	@Schema(description = "평점", example = "5.0", requiredMode = REQUIRED)
+	@NotNull
+	@DecimalMin(value = "0.0")
+	@DecimalMax(value = "5.0")
+	BigDecimal rating
+) {
+}

--- a/soridam-api/src/main/java/sorisoop/soridam/api/review/presentation/response/ReviewPersistResponse.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/review/presentation/response/ReviewPersistResponse.java
@@ -1,0 +1,19 @@
+package sorisoop.soridam.api.review.presentation.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import sorisoop.soridam.domain.review.domain.Review;
+
+@Builder
+public record ReviewPersistResponse(
+	@Schema(description = "review ID", example = "asdfjklsadjklsamlsdfsldm", requiredMode = REQUIRED)
+	String id
+) {
+	public static ReviewPersistResponse from(Review review){
+		return ReviewPersistResponse.builder()
+			.id(review.extractUuid())
+			.build();
+	}
+}

--- a/soridam-auth/src/main/java/sorisoop/soridam/auth/config/SecurityConfig.java
+++ b/soridam-auth/src/main/java/sorisoop/soridam/auth/config/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
 				.requestMatchers(STATIC_RESOURCES_PATTERNS).permitAll()
 				.requestMatchers(PERMIT_ALL_PATTERNS).permitAll()
 				.requestMatchers(PUBLIC_ENDPOINTS).permitAll()
-				.anyRequest().authenticated()
+				.anyRequest().permitAll()
 			)
 			.exceptionHandling(exceptions -> exceptions
 				.authenticationEntryPoint(jwtAuthenticationEntryPoint)
@@ -87,12 +87,10 @@ public class SecurityConfig {
 	CorsConfigurationSource corsConfigurationSource() {
 		return request -> {
 			CorsConfiguration config = new CorsConfiguration();
-			config.setAllowedHeaders(Collections.singletonList("*"));
-			config.setAllowedMethods(Collections.singletonList("*"));
-			config.setAllowedOriginPatterns(Arrays.asList(
-				"*" // TODO: CORS 설정 변경 필요
-			));
-			config.setAllowCredentials(true);
+			config.setAllowedHeaders(Collections.singletonList("*")); // 모든 헤더 허용
+			config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE")); // 필요한 메서드만 허용
+			config.setAllowedOriginPatterns(Arrays.asList("*")); // 특정 도메인 허용
+			config.setAllowCredentials(true); // 인증 정보 포함 허용
 			return config;
 		};
 	}

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/review/application/ReviewCommandService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/review/application/ReviewCommandService.java
@@ -8,7 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import sorisoop.soridam.domain.review.domain.Review;
 import sorisoop.soridam.domain.review.domain.ReviewRepository;
-import sorisoop.soridam.domain.review.exception.ReviewNotFoundException;
 import sorisoop.soridam.domain.user.domain.User;
 import sorisoop.soridam.domain.user.exception.InvalidUserException;
 import sorisoop.soridam.globalutil.user.UserUtil;
@@ -26,17 +25,14 @@ public class ReviewCommandService {
 		return reviewRepository.save(review);
 	}
 
-	public void update(Review review, String content, BigDecimal rating) {
+	public void update(User user, Review review, String content, BigDecimal rating) {
+		validateUser(user.getId(), review.getAuthorId());
 		review.updateContent(content);
 		review.updateRating(rating);
 	}
 
-	public void delete(User user, String id) {
-		Review review = reviewRepository.findById(id)
-			.orElseThrow(ReviewNotFoundException::new);
-
+	public void delete(User user, Review review) {
 		validateUser(user.getId(), review.getAuthorId());
-
 		reviewRepository.delete(review);
 	}
 

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/review/application/ReviewCommandService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/review/application/ReviewCommandService.java
@@ -1,0 +1,48 @@
+package sorisoop.soridam.domain.review.application;
+
+import java.math.BigDecimal;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import sorisoop.soridam.domain.review.domain.Review;
+import sorisoop.soridam.domain.review.domain.ReviewRepository;
+import sorisoop.soridam.domain.review.exception.ReviewNotFoundException;
+import sorisoop.soridam.domain.user.domain.User;
+import sorisoop.soridam.domain.user.exception.InvalidUserException;
+import sorisoop.soridam.globalutil.user.UserUtil;
+import sorisoop.soridam.globalutil.uuid.UuidPrefix;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReviewCommandService {
+	private final ReviewRepository reviewRepository;
+
+	public Review create(String targetId, UuidPrefix reviewType,
+		String authorId, String content, BigDecimal rating) {
+		Review review = Review.create(targetId, reviewType, authorId, content, rating);
+		return reviewRepository.save(review);
+	}
+
+	public void update(Review review, String content, BigDecimal rating) {
+		review.updateContent(content);
+		review.updateRating(rating);
+	}
+
+	public void delete(User user, String id) {
+		Review review = reviewRepository.findById(id)
+			.orElseThrow(ReviewNotFoundException::new);
+
+		validateUser(user.getId(), review.getAuthorId());
+
+		reviewRepository.delete(review);
+	}
+
+	private void validateUser(String user1, String user2) {
+		if (!UserUtil.isSameUser(user1, user2)) {
+			throw new InvalidUserException();
+		}
+	}
+}

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/review/application/ReviewQueryService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/review/application/ReviewQueryService.java
@@ -1,0 +1,19 @@
+package sorisoop.soridam.domain.review.application;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import sorisoop.soridam.domain.review.domain.Review;
+import sorisoop.soridam.domain.review.domain.ReviewRepository;
+import sorisoop.soridam.domain.review.exception.ReviewNotFoundException;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewQueryService {
+	private final ReviewRepository reviewRepository;
+
+	public Review getById(String id) {
+		return reviewRepository.findById(id)
+			.orElseThrow(ReviewNotFoundException::new);
+	}
+}

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/review/domain/Review.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/review/domain/Review.java
@@ -1,0 +1,66 @@
+package sorisoop.soridam.domain.review.domain;
+
+import static jakarta.persistence.EnumType.STRING;
+import static lombok.AccessLevel.PROTECTED;
+import static sorisoop.soridam.globalutil.uuid.UuidPrefix.REVIEW;
+import static sorisoop.soridam.globalutil.uuid.UuidPrefix.USER;
+
+import java.math.BigDecimal;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sorisoop.soridam.common.domain.BaseTimeEntity;
+import sorisoop.soridam.common.domain.UuidExtractable;
+import sorisoop.soridam.globalutil.uuid.PrefixedUuid;
+import sorisoop.soridam.globalutil.uuid.UuidPrefix;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor(access = PROTECTED)
+public class Review extends BaseTimeEntity implements UuidExtractable {
+	@Id
+	@PrefixedUuid(REVIEW)
+	private Long id;
+
+	@Column(nullable = false)
+	private String targetId;
+
+	@Enumerated(STRING)
+	@Column(nullable = false, length = 25)
+	private UuidPrefix reviewType;
+
+	@Column(nullable = false)
+	private String authorId;
+
+	@Column(nullable = false, columnDefinition = "TEXT")
+	private String content;
+
+	@Column(nullable = false, precision = 2, scale = 1)
+	private BigDecimal rating;
+
+	public static Review create(String targetId, UuidPrefix reviewType, String authorId, String content, BigDecimal rating) {
+		return Review.builder()
+			.targetId(reviewType.getPrefix() + targetId)
+			.reviewType(reviewType)
+			.authorId(USER.getPrefix() + authorId)
+			.content(content)
+			.rating(rating)
+			.build();
+	}
+
+	public void updateContent(String content) {
+		this.content = content;
+	}
+
+	public void updateRating(BigDecimal rating) {
+		this.rating = rating;
+	}
+}

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/review/domain/Review.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/review/domain/Review.java
@@ -28,7 +28,7 @@ import sorisoop.soridam.globalutil.uuid.UuidPrefix;
 public class Review extends BaseTimeEntity implements UuidExtractable {
 	@Id
 	@PrefixedUuid(REVIEW)
-	private Long id;
+	private String id;
 
 	@Column(nullable = false)
 	private String targetId;

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/review/domain/ReviewRepository.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/review/domain/ReviewRepository.java
@@ -1,0 +1,9 @@
+package sorisoop.soridam.domain.review.domain;
+
+import java.util.Optional;
+
+public interface ReviewRepository {
+	Review save(Review review);
+
+	Optional<Review> findById(String id);
+}

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/review/domain/ReviewRepository.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/review/domain/ReviewRepository.java
@@ -6,4 +6,6 @@ public interface ReviewRepository {
 	Review save(Review review);
 
 	Optional<Review> findById(String id);
+
+	void delete(Review review);
 }

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/review/domain/ReviewType.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/review/domain/ReviewType.java
@@ -1,0 +1,13 @@
+package sorisoop.soridam.domain.review.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ReviewType {
+	NOISE("소음"),
+	;
+
+	private String description;
+}

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/review/exception/ReviewExceptionCode.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/review/exception/ReviewExceptionCode.java
@@ -1,0 +1,24 @@
+package sorisoop.soridam.domain.review.exception;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import sorisoop.soridam.common.exception.ExceptionCode;
+
+@Getter
+@AllArgsConstructor
+public enum ReviewExceptionCode implements ExceptionCode {
+	REVIEW_NOT_FOUND(NOT_FOUND, "해당 리뷰를 찾을 수 없습니다."),
+	;
+
+	private final HttpStatus status;
+	private final String message;
+
+	@Override
+	public String getCode() {
+		return this.name();
+	}
+}

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/review/exception/ReviewNotFoundException.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/review/exception/ReviewNotFoundException.java
@@ -1,0 +1,11 @@
+package sorisoop.soridam.domain.review.exception;
+
+import static sorisoop.soridam.domain.review.exception.ReviewExceptionCode.REVIEW_NOT_FOUND;
+
+import sorisoop.soridam.common.exception.CustomException;
+
+public class ReviewNotFoundException extends CustomException {
+	public ReviewNotFoundException() {
+		super(REVIEW_NOT_FOUND);
+	}
+}

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/review/infrastructure/JpaReviewRepository.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/review/infrastructure/JpaReviewRepository.java
@@ -1,0 +1,8 @@
+package sorisoop.soridam.domain.review.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import sorisoop.soridam.domain.review.domain.Review;
+
+public interface JpaReviewRepository extends JpaRepository<Review, String> {
+}

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/review/infrastructure/ReviewRepositoryImpl.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/review/infrastructure/ReviewRepositoryImpl.java
@@ -1,0 +1,25 @@
+package sorisoop.soridam.domain.review.infrastructure;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import sorisoop.soridam.domain.review.domain.Review;
+import sorisoop.soridam.domain.review.domain.ReviewRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewRepositoryImpl implements ReviewRepository {
+	private final JpaReviewRepository jpaReviewRepository;
+
+	@Override
+	public Review save(Review review) {
+		return jpaReviewRepository.save(review);
+	}
+
+	@Override
+	public Optional<Review> findById(String id) {
+		return jpaReviewRepository.findById(id);
+	}
+}

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/review/infrastructure/ReviewRepositoryImpl.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/review/infrastructure/ReviewRepositoryImpl.java
@@ -1,5 +1,7 @@
 package sorisoop.soridam.domain.review.infrastructure;
 
+import static sorisoop.soridam.globalutil.uuid.UuidPrefix.REVIEW;
+
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
@@ -20,6 +22,15 @@ public class ReviewRepositoryImpl implements ReviewRepository {
 
 	@Override
 	public Optional<Review> findById(String id) {
-		return jpaReviewRepository.findById(id);
+		return jpaReviewRepository.findById(formatId(id));
+	}
+
+	@Override
+	public void delete(Review review) {
+		jpaReviewRepository.delete(review);
+	}
+
+	private String formatId(String id) {
+		return REVIEW.getPrefix() + id;
 	}
 }

--- a/soridam-global-util/src/main/java/sorisoop/soridam/globalutil/uuid/UuidPrefix.java
+++ b/soridam-global-util/src/main/java/sorisoop/soridam/globalutil/uuid/UuidPrefix.java
@@ -10,7 +10,9 @@ public enum UuidPrefix {
 	NOISE("noise-"),
 	SOUND("sound-"),
 	IMAGE("img-"),
-	DEFAULT("def-");
+	DEFAULT("def-"),
+	REVIEW("review-"),
+	;
 
 	private final String prefix;
 }


### PR DESCRIPTION
## Summary

>- close #68 

**noise entity에서 review 분리하여 새로운 Entity를 생성했습니다.**

## Tasks

- Review, reviewtype 생성
- review crud 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 리뷰 관리 기능 추가
	- 리뷰 생성, 수정, 삭제 지원
	- 소음 관련 리뷰 타입 도입
	- 노이즈 상세 정보 엔드포인트 URL 구조 간소화

- **버그 수정**
	- 노이즈 상세 정보 엔드포인트 URL 구조 간소화

- **기타 변경사항**
	- 리뷰 관련 도메인 및 API 레이어 구현
	- UUID 접두사에 리뷰 타입 추가
	- 보안 설정 수정으로 모든 요청 허용
	- CORS 정책 업데이트로 HTTP 메서드 제한
<!-- end of auto-generated comment: release notes by coderabbit.ai -->