### PR TITLE
refactor/#101 장소 관련 api 구현

### DIFF
--- a/soridam-api/src/main/java/sorisoop/soridam/api/address/application/AddressFacade.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/address/application/AddressFacade.java
@@ -1,0 +1,43 @@
+package sorisoop.soridam.api.address.application;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import sorisoop.soridam.api.address.presentation.request.AddressCreateRequest;
+import sorisoop.soridam.api.address.presentation.response.AddressPersistResponse;
+import sorisoop.soridam.api.address.presentation.response.AddressResponse;
+import sorisoop.soridam.domain.address.application.AddressCommandService;
+import sorisoop.soridam.domain.address.application.AddressQueryService;
+import sorisoop.soridam.domain.address.domain.Address;
+
+@Component
+@RequiredArgsConstructor
+public class AddressFacade {
+	private final AddressQueryService addressQueryService;
+	private final AddressCommandService addressCommandService;
+
+	@Transactional
+	public AddressPersistResponse create(AddressCreateRequest request) {
+		Address address = addressCommandService.save(
+			request.x(),
+			request.y(),
+			request.roadAddress(),
+			request.regionAddress(),
+			request.category()
+		);
+		return AddressPersistResponse.from(address);
+	}
+
+	@Transactional(readOnly = true)
+	public AddressResponse getByRoadAddress(String roadAddress) {
+		Address address = addressQueryService.getByRoadAddress(roadAddress);
+		return AddressResponse.from(address);
+	}
+
+	@Transactional(readOnly = true)
+	public AddressResponse getById(String id) {
+		Address address = addressQueryService.getById(id);
+		return AddressResponse.from(address);
+	}
+}

--- a/soridam-api/src/main/java/sorisoop/soridam/api/address/presentation/AddressApiController.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/address/presentation/AddressApiController.java
@@ -1,0 +1,69 @@
+package sorisoop.soridam.api.address.presentation;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import sorisoop.soridam.api.address.application.AddressFacade;
+import sorisoop.soridam.api.address.presentation.request.AddressCreateRequest;
+import sorisoop.soridam.api.address.presentation.response.AddressPersistResponse;
+import sorisoop.soridam.api.address.presentation.response.AddressResponse;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Address", description = "장소 API")
+@RequestMapping("/api/addresses")
+public class AddressApiController {
+	private final AddressFacade addressFacade;
+
+	@Operation(summary = "id 기반 장소 조회 API", description = """
+			- Description : 이 API는 id로 해당 장소를 조회합니다.
+		""")
+	@ApiResponse(responseCode = "200")
+	@GetMapping("/{id}")
+	public ResponseEntity<AddressResponse> getById(
+		@Parameter(description = "조회할 장소의 ID", example = "address-adsfadsf", required = true)
+		@PathVariable String id
+	) {
+		AddressResponse response = addressFacade.getById(id);
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "id 기반 장소 조회 API", description = """
+			- Description : 이 API는 도로명 주소로 해당 장소를 조회합니다.
+		""")
+	@ApiResponse(responseCode = "200")
+	@GetMapping("/road")
+	public ResponseEntity<AddressResponse> getByRoadAddress(
+		@Parameter(description = "조회할 장소의 ID", example = "충북 청주시 상당구 월평로 189", required = true)
+		@RequestParam String roadAddress
+	) {
+		AddressResponse response = addressFacade.getByRoadAddress(roadAddress);
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "장소 데이터 생성 API", description = """
+			- Description : 이 API는 장소 데이터를 생성합니다.
+		""")
+	@ApiResponse(responseCode = "201")
+	@PostMapping
+	public ResponseEntity<AddressPersistResponse> create(
+		@Valid @RequestBody AddressCreateRequest request
+	) {
+		AddressPersistResponse response = addressFacade.create(request);
+		return ResponseEntity.status(CREATED).body(response);
+	}
+}

--- a/soridam-api/src/main/java/sorisoop/soridam/api/address/presentation/request/AddressCreateRequest.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/address/presentation/request/AddressCreateRequest.java
@@ -1,18 +1,20 @@
-package sorisoop.soridam.api.address.response;
+package sorisoop.soridam.api.address.presentation.request;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
-import sorisoop.soridam.domain.address.domain.Address;
+import sorisoop.soridam.domain.address.domain.enums.Category;
 
 @Builder
-public record AddressResponse(
+public record AddressCreateRequest(
 	@Schema(description = "X 좌표 (경도)", example = "126.9780", requiredMode = REQUIRED)
+	@NotNull
 	double x,
 
 	@Schema(description = "Y 좌표 (위도)", example = "37.5665", requiredMode = REQUIRED)
+	@NotNull
 	double y,
 
 	@Schema(description = "도로명 주소", example = "서울특별시 동대문구 장한로 110 (장안동)", requiredMode = REQUIRED)
@@ -23,16 +25,8 @@ public record AddressResponse(
 	@NotNull
 	String regionAddress,
 
-	@Schema(description = "장소 카테고리", example = "대형마트", requiredMode = REQUIRED)
-	String category
+	@Schema(description = "장소 카테고리", example = "MT1", requiredMode = REQUIRED)
+	@NotNull
+	Category category
 ) {
-	public static AddressResponse from(Address address) {
-		return AddressResponse.builder()
-			.x(address.getLocation().getX())
-			.y(address.getLocation().getY())
-			.roadAddress(address.getRoadAddress())
-			.regionAddress(address.getRegionAddress())
-			.category(address.getCategory().getDescription())
-			.build();
-	}
 }

--- a/soridam-api/src/main/java/sorisoop/soridam/api/address/presentation/response/AddressPersistResponse.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/address/presentation/response/AddressPersistResponse.java
@@ -1,0 +1,19 @@
+package sorisoop.soridam.api.address.presentation.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import sorisoop.soridam.domain.address.domain.Address;
+
+@Builder
+public record AddressPersistResponse(
+	@Schema(description = "address ID", example = "address-asdfjklsadjklsamlsdfsldm", requiredMode = REQUIRED)
+	String id
+) {
+	public static AddressPersistResponse from(Address address) {
+		return AddressPersistResponse.builder()
+			.id(address.getId())
+			.build();
+	}
+}

--- a/soridam-api/src/main/java/sorisoop/soridam/api/address/presentation/response/AddressResponse.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/address/presentation/response/AddressResponse.java
@@ -1,0 +1,38 @@
+package sorisoop.soridam.api.address.presentation.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import sorisoop.soridam.domain.address.domain.Address;
+
+@Builder
+public record AddressResponse(
+	@Schema(description = "X 좌표 (경도)", example = "126.9780", requiredMode = REQUIRED)
+	double x,
+
+	@Schema(description = "Y 좌표 (위도)", example = "37.5665", requiredMode = REQUIRED)
+	double y,
+
+	@Schema(description = "도로명 주소", example = "서울특별시 동대문구 장한로 110 (장안동)", requiredMode = REQUIRED)
+	@NotNull
+	String roadAddress,
+
+	@Schema(description = "지번 주소", example = "서울특별시 동대문구 장안동 366-7", requiredMode = REQUIRED)
+	@NotNull
+	String regionAddress,
+
+	@Schema(description = "장소 카테고리", example = "대형마트", requiredMode = REQUIRED)
+	String category
+) {
+	public static AddressResponse from(Address address) {
+		return AddressResponse.builder()
+			.x(address.getLocation().getX())
+			.y(address.getLocation().getY())
+			.roadAddress(address.getRoadAddress())
+			.regionAddress(address.getRegionAddress())
+			.category(address.getCategory().getDescription())
+			.build();
+	}
+}

--- a/soridam-api/src/main/java/sorisoop/soridam/api/noise/application/NoiseFacade.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/noise/application/NoiseFacade.java
@@ -20,6 +20,7 @@ import sorisoop.soridam.api.noise.presentation.response.NoiseSummaryListResponse
 import sorisoop.soridam.api.noise.presentation.response.NoiseSummaryResponse;
 import sorisoop.soridam.api.review.presentation.response.ReviewResponse;
 import sorisoop.soridam.domain.address.application.AddressCommandService;
+import sorisoop.soridam.domain.address.application.AddressQueryService;
 import sorisoop.soridam.domain.address.domain.Address;
 import sorisoop.soridam.domain.noise.application.NoiseCommandService;
 import sorisoop.soridam.domain.noise.application.NoiseQueryService;
@@ -39,6 +40,7 @@ public class NoiseFacade {
 	private final NoiseQueryService noiseQueryService;
 	private final UserQueryService userQueryService;
 	private final AddressCommandService addressCommandService;
+	private final AddressQueryService addressQueryService;
 	private final ReviewQueryService reviewQueryService;
 
 	@Transactional(readOnly = true)
@@ -81,13 +83,17 @@ public class NoiseFacade {
 	@Transactional
 	public NoisePersistResponse createNoise(NoiseCreateRequest request) {
 		User user = userQueryService.me();
-		Address address = addressCommandService.save(
-			request.x(),
-			request.y(),
-			request.roadAddress(),
-			request.regionAddress(),
-			request.category()
-		);
+		Address address = addressQueryService.getByRoadAddress(request.roadAddress());
+
+		if(address == null) {
+			address = addressCommandService.save(
+				request.x(),
+				request.y(),
+				request.roadAddress(),
+				request.regionAddress(),
+				request.category()
+			);
+		}
 
 		Noise noise = noiseCommandService.createNoise(
 			user,

--- a/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/response/NoiseResponse.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/response/NoiseResponse.java
@@ -4,7 +4,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.time.format.DateTimeFormatter;
 
-import sorisoop.soridam.api.address.response.AddressResponse;
+import sorisoop.soridam.api.address.presentation.response.AddressResponse;
 import sorisoop.soridam.domain.noise.domain.Noise;
 
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/response/NoiseSummaryResponse.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/response/NoiseSummaryResponse.java
@@ -4,7 +4,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.time.format.DateTimeFormatter;
 
-import sorisoop.soridam.api.address.response.AddressResponse;
+import sorisoop.soridam.api.address.presentation.response.AddressResponse;
 import sorisoop.soridam.domain.noise.domain.Noise;
 
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/address/application/AddressQueryService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/address/application/AddressQueryService.java
@@ -1,0 +1,24 @@
+package sorisoop.soridam.domain.address.application;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import sorisoop.soridam.domain.address.domain.Address;
+import sorisoop.soridam.domain.address.domain.AddressRepository;
+import sorisoop.soridam.domain.address.exception.AddressNotFoundException;
+
+@Service
+@RequiredArgsConstructor
+public class AddressQueryService {
+	private final AddressRepository addressRepository;
+
+	public Address getByRoadAddress(String roadAddress) {
+		return addressRepository.findByRoadAddress(roadAddress)
+			.orElse(null);
+	}
+
+	public Address mustExistByRoadAddress(String roadAddress) {
+		return addressRepository.findByRoadAddress(roadAddress)
+			.orElseThrow(AddressNotFoundException::new);
+	}
+}

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/address/application/AddressQueryService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/address/application/AddressQueryService.java
@@ -14,11 +14,11 @@ public class AddressQueryService {
 
 	public Address getByRoadAddress(String roadAddress) {
 		return addressRepository.findByRoadAddress(roadAddress)
-			.orElse(null);
+			.orElseThrow(AddressNotFoundException::new);
 	}
 
-	public Address mustExistByRoadAddress(String roadAddress) {
-		return addressRepository.findByRoadAddress(roadAddress)
+	public Address getById(String id) {
+		return addressRepository.findById(id)
 			.orElseThrow(AddressNotFoundException::new);
 	}
 }

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/address/domain/Address.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/address/domain/Address.java
@@ -30,7 +30,7 @@ public class Address {
 	@Column(nullable = false, columnDefinition = "geometry(Point, 4326)")
 	private Point location;
 
-	@Column(nullable = false)
+	@Column(nullable = false, unique = true)
 	private String roadAddress;
 
 	@Column(nullable = false)

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/address/domain/AddressRepository.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/address/domain/AddressRepository.java
@@ -11,4 +11,6 @@ public interface AddressRepository {
 	List<Address> findAll();
 
 	void delete(Address address);
+
+	Optional<Address> findByRoadAddress(String roadAddress);
 }

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/address/exception/AddressExceptionCode.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/address/exception/AddressExceptionCode.java
@@ -1,0 +1,24 @@
+package sorisoop.soridam.domain.address.exception;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import sorisoop.soridam.common.exception.ExceptionCode;
+
+@Getter
+@AllArgsConstructor
+public enum AddressExceptionCode implements ExceptionCode {
+	ADDRESS_NOT_FOUND(NOT_FOUND, "해당 주소를 찾을 수 없습니다."),
+	;
+
+	private final HttpStatus status;
+	private final String message;
+
+	@Override
+	public String getCode() {
+		return this.name();
+	}
+}

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/address/exception/AddressNotFoundException.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/address/exception/AddressNotFoundException.java
@@ -1,0 +1,11 @@
+package sorisoop.soridam.domain.address.exception;
+
+import static sorisoop.soridam.domain.address.exception.AddressExceptionCode.ADDRESS_NOT_FOUND;
+
+import sorisoop.soridam.common.exception.CustomException;
+
+public class AddressNotFoundException extends CustomException {
+	public AddressNotFoundException() {
+		super(ADDRESS_NOT_FOUND);
+	}
+}

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/impl/AddressRepositoryImpl.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/impl/AddressRepositoryImpl.java
@@ -34,4 +34,9 @@ public class AddressRepositoryImpl implements AddressRepository {
 	public void delete(Address address) {
 		jpaAddressRepository.delete(address);
 	}
+
+	@Override
+	public Optional<Address> findByRoadAddress(String roadAddress) {
+		return jpaAddressRepository.findByRoadAddress(roadAddress);
+	}
 }

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/jpa/JpaAddressRepository.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/jpa/JpaAddressRepository.java
@@ -1,8 +1,11 @@
 package sorisoop.soridam.infra.repository.jpa;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import sorisoop.soridam.domain.address.domain.Address;
 
 public interface JpaAddressRepository extends JpaRepository<Address, String> {
+	Optional<Address> findByRoadAddress(String roadAddress);
 }


### PR DESCRIPTION
## Summary

>- close #101 

**좌표 기반 소음 조회를 장소 기반 소음 조회로 변경하기 위해 장소 api를 구현했습니다**

## Tasks

- address roadAddress unique 설정
- address api 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 주소 생성, 조회(도로명, ID 기반)를 위한 REST API 엔드포인트가 추가되었습니다.
    - 주소 생성 요청 및 응답, 조회 응답을 위한 데이터 구조가 추가되었습니다.
    - 주소 도메인에서 도로명 주소의 중복 등록을 방지하는 기능이 추가되었습니다.
- **버그 수정**
    - 소음 생성 시 기존 도로명 주소가 있으면 재사용하여 중복 주소 생성을 방지합니다.
- **기타**
    - 주소 조회 실패 시 일관된 예외 및 에러 코드가 제공됩니다.
    - 일부 패키지 및 import 경로가 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->