### PR TITLE
refactor/#102 noise, address, review api 분리

### DIFF
--- a/soridam-api/src/main/java/sorisoop/soridam/api/address/application/AddressFacade.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/address/application/AddressFacade.java
@@ -40,4 +40,21 @@ public class AddressFacade {
 		Address address = addressQueryService.getById(id);
 		return AddressResponse.from(address);
 	}
+
+	@Transactional
+	public AddressPersistResponse getOrCreate(AddressCreateRequest request) {
+		Address address = addressQueryService.getByRoadAddress(request.roadAddress());
+
+		if(address == null) {
+			address = addressCommandService.save(
+				request.x(),
+				request.y(),
+				request.roadAddress(),
+				request.regionAddress(),
+				request.category()
+			);
+		}
+
+		return AddressPersistResponse.from(address);
+	}
 }

--- a/soridam-api/src/main/java/sorisoop/soridam/api/address/presentation/AddressApiController.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/address/presentation/AddressApiController.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -42,16 +41,16 @@ public class AddressApiController {
 		return ResponseEntity.ok(response);
 	}
 
-	@Operation(summary = "id 기반 장소 조회 API", description = """
-			- Description : 이 API는 도로명 주소로 해당 장소를 조회합니다.
+	@Operation(summary = "도로명 주소 기반 장소 조회 또는 생성 API", description = """
+			- Description : 이 API는 도로명 주소로 장소를 조회하고,
+			존재하지 않으면 새로 데이터를 생성한 뒤 반환합니다.
 		""")
 	@ApiResponse(responseCode = "200")
-	@GetMapping("/road")
-	public ResponseEntity<AddressResponse> getByRoadAddress(
-		@Parameter(description = "조회할 장소의 ID", example = "충북 청주시 상당구 월평로 189", required = true)
-		@RequestParam String roadAddress
+	@PostMapping("/resolve")
+	public ResponseEntity<AddressPersistResponse> getByRoadAddress(
+		@Valid @RequestBody AddressCreateRequest request
 	) {
-		AddressResponse response = addressFacade.getByRoadAddress(roadAddress);
+		AddressPersistResponse response = addressFacade.getOrCreate(request);
 		return ResponseEntity.ok(response);
 	}
 

--- a/soridam-api/src/main/java/sorisoop/soridam/api/noise/application/NoiseFacade.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/noise/application/NoiseFacade.java
@@ -19,7 +19,6 @@ import sorisoop.soridam.api.noise.presentation.response.NoiseReviewResponse;
 import sorisoop.soridam.api.noise.presentation.response.NoiseSummaryListResponse;
 import sorisoop.soridam.api.noise.presentation.response.NoiseSummaryResponse;
 import sorisoop.soridam.api.review.presentation.response.ReviewResponse;
-import sorisoop.soridam.domain.address.application.AddressCommandService;
 import sorisoop.soridam.domain.address.application.AddressQueryService;
 import sorisoop.soridam.domain.address.domain.Address;
 import sorisoop.soridam.domain.noise.application.NoiseCommandService;
@@ -39,13 +38,12 @@ public class NoiseFacade {
 	private final NoiseCommandService noiseCommandService;
 	private final NoiseQueryService noiseQueryService;
 	private final UserQueryService userQueryService;
-	private final AddressCommandService addressCommandService;
 	private final AddressQueryService addressQueryService;
 	private final ReviewQueryService reviewQueryService;
 
 	@Transactional(readOnly = true)
-	public Optional<NoiseReviewResponse> getDetailNoise(double x, double y) {
-		List<Noise> results = noiseQueryService.getDetailNoise(x, y);
+	public Optional<NoiseReviewResponse> getDetailNoise(String addressId) {
+		List<Noise> results = noiseQueryService.getDetailNoise(addressId);
 
 		List<String> resultIds = results.stream()
 			.map(Noise::getId)

--- a/soridam-api/src/main/java/sorisoop/soridam/api/noise/application/NoiseFacade.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/noise/application/NoiseFacade.java
@@ -4,7 +4,6 @@ import static sorisoop.soridam.globalutil.uuid.UuidPrefix.NOISE;
 import static sorisoop.soridam.globalutil.uuid.UuidPrefix.USER;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,7 +14,6 @@ import sorisoop.soridam.api.noise.presentation.request.NoiseSearchRequest;
 import sorisoop.soridam.api.noise.presentation.response.NoiseListResponse;
 import sorisoop.soridam.api.noise.presentation.response.NoisePersistResponse;
 import sorisoop.soridam.api.noise.presentation.response.NoiseResponse;
-import sorisoop.soridam.api.noise.presentation.response.NoiseReviewResponse;
 import sorisoop.soridam.api.noise.presentation.response.NoiseSummaryListResponse;
 import sorisoop.soridam.api.noise.presentation.response.NoiseSummaryResponse;
 import sorisoop.soridam.api.review.presentation.response.ReviewResponse;
@@ -42,24 +40,20 @@ public class NoiseFacade {
 	private final ReviewQueryService reviewQueryService;
 
 	@Transactional(readOnly = true)
-	public Optional<NoiseReviewResponse> getDetailNoise(String addressId) {
+	public NoiseSummaryListResponse getNoisesByAddress(String addressId) {
 		List<Noise> results = noiseQueryService.getDetailNoise(addressId);
 
 		List<String> resultIds = results.stream()
 			.map(Noise::getId)
 			.toList();
 
-		if (results.isEmpty()) return Optional.empty();
-
-		List<NoiseSummaryResponse> noises = results.stream()
-			.map(NoiseSummaryResponse::from)
-			.toList();
-
 		List<ReviewResponse> reviews = reviewQueryService.getByTargetIdIn(resultIds).stream()
 			.map(ReviewResponse::from)
 			.toList();
 
-		return Optional.of(NoiseReviewResponse.of(noises, reviews));
+		return NoiseSummaryListResponse.of(results.stream()
+			.map(NoiseSummaryResponse::from)
+			.toList());
 	}
 
 	@Transactional(readOnly = true)

--- a/soridam-api/src/main/java/sorisoop/soridam/api/noise/application/NoiseFacade.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/noise/application/NoiseFacade.java
@@ -83,17 +83,7 @@ public class NoiseFacade {
 	@Transactional
 	public NoisePersistResponse createNoise(NoiseCreateRequest request) {
 		User user = userQueryService.me();
-		Address address = addressQueryService.getByRoadAddress(request.roadAddress());
-
-		if(address == null) {
-			address = addressCommandService.save(
-				request.x(),
-				request.y(),
-				request.roadAddress(),
-				request.regionAddress(),
-				request.category()
-			);
-		}
+		Address address = addressQueryService.getById(request.addressId());
 
 		Noise noise = noiseCommandService.createNoise(
 			user,

--- a/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/NoiseApiController.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/NoiseApiController.java
@@ -2,8 +2,6 @@ package sorisoop.soridam.api.noise.presentation;
 
 import static org.springframework.http.HttpStatus.CREATED;
 
-import java.util.Optional;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,7 +24,6 @@ import sorisoop.soridam.api.noise.presentation.request.NoiseSearchRequest;
 import sorisoop.soridam.api.noise.presentation.response.NoiseListResponse;
 import sorisoop.soridam.api.noise.presentation.response.NoisePersistResponse;
 import sorisoop.soridam.api.noise.presentation.response.NoiseResponse;
-import sorisoop.soridam.api.noise.presentation.response.NoiseReviewResponse;
 import sorisoop.soridam.api.noise.presentation.response.NoiseSummaryListResponse;
 import sorisoop.soridam.domain.noise.domain.NoiseLevel;
 import sorisoop.soridam.domain.noise.domain.Radius;
@@ -78,14 +75,11 @@ public class NoiseApiController {
 	@ApiResponse(responseCode = "200", description = "요청 성공")
 	@ApiResponse(responseCode = "204", description = "결과 없음")
 	@GetMapping("/by-address/{id}")
-	public ResponseEntity<NoiseReviewResponse> getDetailNoise(
+	public ResponseEntity<NoiseSummaryListResponse> getDetailNoise(
 		@PathVariable String id
 	){
-		Optional<NoiseReviewResponse> response = noiseFacade.getDetailNoise(id);
-
-		return response
-			.map(ResponseEntity::ok)
-			.orElseGet(() -> ResponseEntity.noContent().build());
+		NoiseSummaryListResponse response = noiseFacade.getNoisesByAddress(id);
+		return ResponseEntity.ok(response);
   	}
 
 	@Operation(summary = "소음 데이터 생성 API", description = """

--- a/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/NoiseApiController.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/NoiseApiController.java
@@ -77,17 +77,11 @@ public class NoiseApiController {
 		""")
 	@ApiResponse(responseCode = "200", description = "요청 성공")
 	@ApiResponse(responseCode = "204", description = "결과 없음")
-	@GetMapping("/location")
+	@GetMapping("/by-address/{id}")
 	public ResponseEntity<NoiseReviewResponse> getDetailNoise(
-		@RequestParam
-		@Parameter(description = "x 좌표", example = "127.07150", required = true)
-		double x,
-
-		@RequestParam
-		@Parameter(description = "y 좌표", example = "37.3405", required = true)
-		double y
+		@PathVariable String id
 	){
-		Optional<NoiseReviewResponse> response = noiseFacade.getDetailNoise(x, y);
+		Optional<NoiseReviewResponse> response = noiseFacade.getDetailNoise(id);
 
 		return response
 			.map(ResponseEntity::ok)

--- a/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/request/NoiseCreateRequest.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/request/NoiseCreateRequest.java
@@ -7,29 +7,12 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.Builder;
-import sorisoop.soridam.domain.address.domain.enums.Category;
 
 @Builder
 public record NoiseCreateRequest(
-	@Schema(description = "X 좌표 (경도)", example = "126.9780", requiredMode = REQUIRED)
+	@Schema(description = "장소 id", example = "address-adsfsdfasdaf", requiredMode = REQUIRED)
 	@NotNull
-	double x,
-
-	@Schema(description = "Y 좌표 (위도)", example = "37.5665", requiredMode = REQUIRED)
-	@NotNull
-	double y,
-
-	@Schema(description = "도로명 주소", example = "서울특별시 동대문구 장한로 110 (장안동)", requiredMode = REQUIRED)
-	@NotNull
-	String roadAddress,
-
-	@Schema(description = "지번 주소", example = "서울특별시 동대문구 장안동 366-7", requiredMode = REQUIRED)
-	@NotNull
-	String regionAddress,
-
-	@Schema(description = "장소 카테고리", example = "MT1", requiredMode = REQUIRED)
-	@NotNull
-	Category category,
+	String addressId,
 
 	@Schema(description = "평균 데시벨", example = "50", requiredMode = REQUIRED)
 	@NotNull

--- a/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/request/NoiseCreateRequest.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/request/NoiseCreateRequest.java
@@ -3,7 +3,6 @@ package sorisoop.soridam.api.noise.presentation.request;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.Builder;
@@ -22,10 +21,6 @@ public record NoiseCreateRequest(
 	@Schema(description = "최대 데시벨", example = "70", requiredMode = REQUIRED)
 	@NotNull
 	@Positive
-	int maxDecibel,
-
-	@Schema(description = "리뷰 내용", example = "소음이 많은 환경", requiredMode = REQUIRED)
-	@NotBlank
-	String review
+	int maxDecibel
 ) {
 }

--- a/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/response/NoiseSummaryResponse.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/response/NoiseSummaryResponse.java
@@ -12,6 +12,9 @@ import lombok.Builder;
 
 @Builder
 public record NoiseSummaryResponse(
+	@Schema(description = "소음 ID", requiredMode = REQUIRED)
+	String id,
+
 	@Schema(description = "소음 발생 지점 주소", requiredMode = REQUIRED)
 	AddressResponse address,
 
@@ -25,6 +28,7 @@ public record NoiseSummaryResponse(
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분");
 		AddressResponse addressResponse = AddressResponse.from(noise.getAddress());
 		return builder()
+			.id(noise.getId())
 			.address(addressResponse)
 			.avgDecibel(noise.getAvgDecibel())
 			.createdAt(formatter.format(noise.getCreatedAt()))

--- a/soridam-api/src/main/java/sorisoop/soridam/api/review/ReviewApiController.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/review/ReviewApiController.java
@@ -2,6 +2,8 @@ package sorisoop.soridam.api.review;
 
 import static org.springframework.http.HttpStatus.CREATED;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,6 +21,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import sorisoop.soridam.api.noise.presentation.response.NoiseSummaryResponse;
 import sorisoop.soridam.api.review.application.ReviewFacade;
 import sorisoop.soridam.api.review.presentation.request.ReviewCreateRequest;
 import sorisoop.soridam.api.review.presentation.request.ReviewUpdateRequest;
@@ -72,6 +75,22 @@ public class ReviewApiController {
 		@Parameter(description = "리뷰 종류", example = "NOISE", required = true)
 		@RequestParam UuidPrefix reviewType) {
 		ReviewListResponse response = reviewFacade.getReviews(targetId, reviewType);
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "Noise 리스트 기반 리뷰 조회 API", description = """
+        - Description : Noise 리스트로부터 targetId를 추출해서 리뷰들을 조회합니다.
+    """)
+	@ApiResponse(responseCode = "200", description = "리뷰 조회 성공")
+	@PostMapping("/by-noise-summaries")
+	public ResponseEntity<ReviewListResponse> getReviewsByNoiseSummaries(
+		@RequestBody List<NoiseSummaryResponse> noiseSummaries
+	) {
+		List<String> resultIds = noiseSummaries.stream()
+			.map(NoiseSummaryResponse::id)
+			.toList();
+
+		ReviewListResponse response = reviewFacade.getReviewsByTargetIds(resultIds);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/soridam-api/src/main/java/sorisoop/soridam/api/review/application/ReviewFacade.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/review/application/ReviewFacade.java
@@ -67,4 +67,14 @@ public class ReviewFacade {
 
 		return ReviewListResponse.of(responses);
 	}
+
+	@Transactional(readOnly = true)
+	public ReviewListResponse getReviewsByTargetIds(List<String> targetIds) {
+		List<Review> reviews = reviewQueryService.getByTargetIdIn(targetIds);
+		List<ReviewResponse> responses = reviews.stream()
+			.map(ReviewResponse::from)
+			.toList();
+
+		return ReviewListResponse.of(responses);
+	}
 }

--- a/soridam-api/src/main/java/sorisoop/soridam/api/review/presentation/response/ReviewResponse.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/review/presentation/response/ReviewResponse.java
@@ -8,6 +8,7 @@ import sorisoop.soridam.domain.review.domain.Review;
 
 @Builder
 public record ReviewResponse(
+	String targetId,
 	String authorId,
 	String content,
 	BigDecimal rating,
@@ -16,6 +17,7 @@ public record ReviewResponse(
 	public static ReviewResponse from(Review review) {
 		return ReviewResponse.builder()
 			.authorId(review.getAuthor().getNickname())
+			.targetId(review.getTargetId())
 			.content(review.getContent())
 			.rating(review.getRating())
 			.createdAt(review.getCreatedAt())

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/address/application/AddressQueryService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/address/application/AddressQueryService.java
@@ -14,7 +14,7 @@ public class AddressQueryService {
 
 	public Address getByRoadAddress(String roadAddress) {
 		return addressRepository.findByRoadAddress(roadAddress)
-			.orElseThrow(AddressNotFoundException::new);
+			.orElse(null);
 	}
 
 	public Address getById(String id) {

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/noise/application/NoiseQueryService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/noise/application/NoiseQueryService.java
@@ -19,9 +19,8 @@ public class NoiseQueryService {
 	private final NoiseRepository noiseRepository;
 	private final GeometryUtils geometryUtils;
 
-	public List<Noise> getDetailNoise(double x, double y) {
-		Point point = geometryUtils.createPoint(x, y);
-		return noiseRepository.findAllByAddress_Location(point);
+	public List<Noise> getDetailNoise(String addressId) {
+		return noiseRepository.findByAddressId(addressId);
 	}
 
 	public List<Noise> getNearbyNoise(double x, double y, Radius radius, NoiseLevel noiseLevel) {

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/noise/domain/NoiseRepository.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/noise/domain/NoiseRepository.java
@@ -6,8 +6,6 @@ import java.util.Optional;
 import org.locationtech.jts.geom.Point;
 
 public interface NoiseRepository {
-	List<Noise> findAllByAddress_Location(Point point);
-
 	List<Noise> findByAvgDecibelAndPoint(Point point, Radius radius, NoiseLevel noiseLevel);
 
 	Optional<Noise> findById(String id);
@@ -17,4 +15,6 @@ public interface NoiseRepository {
 	void delete(Noise noise);
 
 	List<Noise> findByUserId(String userId);
+
+	List<Noise> findByAddressId(String addressId);
 }

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/impl/NoiseRepositoryImpl.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/impl/NoiseRepositoryImpl.java
@@ -21,11 +21,6 @@ public class NoiseRepositoryImpl implements NoiseRepository {
 	private final QueryNoiseRepository queryNoiseRepository;
 
 	@Override
-	public List<Noise> findAllByAddress_Location(Point point) {
-		return jpaNoiseRepository.findAllByAddress_Location(point);
-	}
-
-	@Override
 	public List<Noise> findByAvgDecibelAndPoint(Point point, Radius radius, NoiseLevel noiseLevel) {
 		return queryNoiseRepository.findByAvgDecibelAndPoint(point, radius, noiseLevel);
 	}
@@ -48,5 +43,10 @@ public class NoiseRepositoryImpl implements NoiseRepository {
 	@Override
 	public List<Noise> findByUserId(String userId) {
 		return jpaNoiseRepository.findByUserId(userId);
+	}
+
+	@Override
+	public List<Noise> findByAddressId(String addressId) {
+		return jpaNoiseRepository.findByAddressId(addressId);
 	}
 }

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/jpa/JpaNoiseRepository.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/jpa/JpaNoiseRepository.java
@@ -2,13 +2,12 @@ package sorisoop.soridam.infra.repository.jpa;
 
 import java.util.List;
 
-import org.locationtech.jts.geom.Point;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import sorisoop.soridam.domain.noise.domain.Noise;
 
 public interface JpaNoiseRepository extends JpaRepository<Noise, String> {
-	List<Noise> findAllByAddress_Location(Point location);
-
 	List<Noise> findByUserId(String userId);
+
+	List<Noise> findByAddressId(String addressId);
 }


### PR DESCRIPTION
## Summary

>- close #103 

**noise, address, review api 분리**

## Tasks

- noise 생성 시 address 생성 api 분리
- Noise 상세 조회 시 review 조회 api 분리



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 주소 정보가 없을 경우 자동으로 생성하는 주소 조회/생성 API가 추가되었습니다.
    - 여러 소음 요약 정보에 대한 리뷰를 한 번에 조회할 수 있는 리뷰 API가 추가되었습니다.

- **기능 개선**
    - 소음 데이터 조회 방식이 좌표 기반에서 주소 ID 기반으로 변경되었습니다.
    - 소음 생성 시 주소 ID로만 등록하도록 요청 필드가 단순화되었습니다.
    - 소음 요약 및 리뷰 응답에 각각 소음 ID, 대상 ID 필드가 추가되었습니다.

- **API 변경**
    - 주소, 소음 관련 엔드포인트의 요청 방식 및 파라미터가 변경되었습니다(좌표 → 주소 ID, GET → POST 등).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->