### PR TITLE
feature/#111 소음 정렬, 필터링 추가

### DIFF
--- a/soridam-api/src/main/java/sorisoop/soridam/api/common/SortDirection.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/common/SortDirection.java
@@ -1,0 +1,13 @@
+package sorisoop.soridam.api.common;
+
+import org.springframework.data.domain.Sort;
+
+public enum SortDirection {
+	ASC,
+	DESC;
+
+	public Sort.Direction toSpringSortDirection() {
+		return this == ASC ? Sort.Direction.ASC : Sort.Direction.DESC;
+	}
+}
+

--- a/soridam-api/src/main/java/sorisoop/soridam/api/noise/application/NoiseFacade.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/noise/application/NoiseFacade.java
@@ -2,12 +2,14 @@ package sorisoop.soridam.api.noise.application;
 
 import java.util.List;
 
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import sorisoop.soridam.api.common.SortDirection;
+import sorisoop.soridam.api.noise.presentation.enums.NoiseLevel;
+import sorisoop.soridam.api.noise.presentation.enums.NoiseSortField;
 import sorisoop.soridam.api.noise.presentation.request.NoiseCreateRequest;
 import sorisoop.soridam.api.noise.presentation.response.NoiseListResponse;
 import sorisoop.soridam.api.noise.presentation.response.NoisePersistResponse;
@@ -31,20 +33,38 @@ public class NoiseFacade {
 	private final AddressQueryService addressQueryService;
 
 	@Transactional(readOnly = true)
-	public SliceResponse<NoiseSummaryResponse> getNoisesByAddress(Long addressId, Long lastId, int limit) {
-		Pageable pageable = PageRequest.of(0, limit + 1);
-		List<NoiseSummaryResponse> results = noiseQueryService.getDetailNoise(addressId, lastId, pageable).stream()
+	public SliceResponse<NoiseSummaryResponse> getByAddressWithCursorAndAvgDecibelRange(Long addressId, String lastValue, int limit, NoiseLevel level, NoiseSortField sort, SortDirection order) {
+		Sort sortSpec = Sort.by(order.toSpringSortDirection(), sort.getValue());
+
+		int minDecibel = (level != null) ? level.getMinDecibel() : 0;
+		int maxDecibel = (level != null) ? level.getMaxDecibel() : 120;
+
+		List<Noise> noises = noiseQueryService.getByAddressWithCursorAndAvgDecibelRange(addressId, lastValue,
+			minDecibel, maxDecibel, limit + 1, sortSpec);
+
+		boolean hasNext = noises.size() > limit;
+		if (hasNext) {
+			noises = noises.subList(0, limit);
+		}
+
+		List<NoiseSummaryResponse> responses = noises.stream()
 			.map(NoiseSummaryResponse::from)
 			.toList();
 
-		boolean hasNext = results.size() > limit;
-		if (hasNext) {
-			results = results.subList(0, limit);
-		}
+		String newLastCursor = noises.isEmpty()
+			? null
+			: extractCursorValue(responses.get(responses.size() - 1), sortSpec);
 
-		Long newLastId = results.isEmpty() ? null : results.getLast().id();
+		return SliceResponse.of(responses, newLastCursor, hasNext);
+	}
 
-		return SliceResponse.of(results, newLastId, hasNext);
+	private String extractCursorValue(NoiseSummaryResponse response, Sort sort) {
+		String sortProperty = sort.stream().findFirst().orElseThrow().getProperty();
+		return switch (sortProperty) {
+			case "id" -> response.id().toString();
+			case "avgDecibel" -> String.valueOf(response.avgDecibel());
+			default -> throw new IllegalArgumentException("지원하지 않는 정렬 기준입니다: " + sortProperty);
+		};
 	}
 
 

--- a/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/NoiseApiController.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/NoiseApiController.java
@@ -18,13 +18,16 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import sorisoop.soridam.api.common.SortDirection;
 import sorisoop.soridam.api.noise.application.NoiseFacade;
+import sorisoop.soridam.api.noise.presentation.enums.NoiseSortField;
 import sorisoop.soridam.api.noise.presentation.request.NoiseCreateRequest;
 import sorisoop.soridam.api.noise.presentation.response.NoiseListResponse;
 import sorisoop.soridam.api.noise.presentation.response.NoisePersistResponse;
 import sorisoop.soridam.api.noise.presentation.response.NoiseResponse;
 import sorisoop.soridam.api.noise.presentation.response.NoiseSummaryResponse;
 import sorisoop.soridam.common.response.SliceResponse;
+import sorisoop.soridam.api.noise.presentation.enums.NoiseLevel;
 
 @RestController
 @RequiredArgsConstructor
@@ -54,10 +57,28 @@ public class NoiseApiController {
 	@GetMapping("/address/{addressId}")
 	public ResponseEntity<SliceResponse<NoiseSummaryResponse>> getDetailNoise(
 		@PathVariable Long addressId,
-		@RequestParam(required = false) Long lastId,
-		@RequestParam int limit
+
+		@RequestParam(required = false)
+		@Parameter(description = "커서 페이징을 위한 마지막 noiseId", example = "1024")
+		String lastValue,
+
+		@RequestParam(defaultValue = "10")
+		@Parameter(description = "가져올 데이터 개수", example = "10")
+		int limit,
+
+		@RequestParam(required = false)
+		@Parameter(description = "소음 수준 필터링", example = "QUIET")
+		NoiseLevel level,
+
+		@RequestParam(defaultValue = "ID")
+		@Parameter(description = "정렬 기준 필드", example = "ID")
+		NoiseSortField sort,
+
+		@RequestParam(defaultValue = "DESC")
+		@Parameter(description = "정렬 순서", example = "DESC")
+		SortDirection order
 	){
-		SliceResponse<NoiseSummaryResponse> response = noiseFacade.getNoisesByAddress(addressId, lastId, limit);
+		SliceResponse<NoiseSummaryResponse> response = noiseFacade.getByAddressWithCursorAndAvgDecibelRange(addressId, lastValue, limit, level, sort, order);
 		return ResponseEntity.ok(response);
   	}
 

--- a/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/enums/NoiseLevel.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/enums/NoiseLevel.java
@@ -1,4 +1,4 @@
-package sorisoop.soridam.domain.noise.domain;
+package sorisoop.soridam.api.noise.presentation.enums;
 
 import java.util.Arrays;
 

--- a/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/enums/NoiseSortField.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/enums/NoiseSortField.java
@@ -1,0 +1,20 @@
+package sorisoop.soridam.api.noise.presentation.enums;
+
+import org.springframework.data.domain.Sort;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NoiseSortField {
+	AVG_DECIBEL("avgDecibel"),
+	ID("id");
+
+	private final String value;
+
+	public Sort toSort(String order) {
+		Sort.Direction direction = order.equalsIgnoreCase("asc") ? Sort.Direction.ASC : Sort.Direction.DESC;
+		return Sort.by(direction, this.value);
+	}
+}

--- a/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/response/NoiseResponse.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/response/NoiseResponse.java
@@ -9,6 +9,7 @@ import sorisoop.soridam.domain.noise.domain.Noise;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+import sorisoop.soridam.domain.noise.domain.NoiseLevel;
 
 @Builder
 public record NoiseResponse(
@@ -25,7 +26,10 @@ public record NoiseResponse(
 	int maxDecibel,
 
 	@Schema(description = "작성일자", example = "2024년 12월 14일 21시 37분", requiredMode = REQUIRED)
-	String createdAt
+	String createdAt,
+
+	@Schema(description = "소음 레벨", example = "NOLMAL", requiredMode = REQUIRED)
+	NoiseLevel noiseLevel
 ) {
 	public static NoiseResponse from(Noise noise) {
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분");
@@ -36,6 +40,7 @@ public record NoiseResponse(
 			.avgDecibel(noise.getAvgDecibel())
 			.maxDecibel(noise.getMaxDecibel())
 			.createdAt(noise.getCreatedAt().format(formatter))
+			.noiseLevel(NoiseLevel.from(noise.getAvgDecibel()))
 			.build();
 	}
 }

--- a/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/response/NoiseResponse.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/response/NoiseResponse.java
@@ -9,7 +9,7 @@ import sorisoop.soridam.domain.noise.domain.Noise;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
-import sorisoop.soridam.domain.noise.domain.NoiseLevel;
+import sorisoop.soridam.api.noise.presentation.enums.NoiseLevel;
 
 @Builder
 public record NoiseResponse(

--- a/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/response/NoiseSummaryResponse.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/noise/presentation/response/NoiseSummaryResponse.java
@@ -4,19 +4,17 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.time.format.DateTimeFormatter;
 
-import sorisoop.soridam.api.address.presentation.response.AddressResponse;
-import sorisoop.soridam.domain.noise.domain.Noise;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+import sorisoop.soridam.domain.noise.domain.Noise;
 
 @Builder
 public record NoiseSummaryResponse(
 	@Schema(description = "소음 ID", requiredMode = REQUIRED)
 	Long id,
 
-	@Schema(description = "소음 발생 지점 주소", requiredMode = REQUIRED)
-	AddressResponse address,
+	@Schema(description = "작성자", example = "nninjo_on", requiredMode = REQUIRED)
+	String author,
 
 	@Schema(description = "평균 소음 데시벨", example = "50", requiredMode = REQUIRED)
 	int avgDecibel,
@@ -26,10 +24,9 @@ public record NoiseSummaryResponse(
 ) {
 	public static NoiseSummaryResponse from(Noise noise) {
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분");
-		AddressResponse addressResponse = AddressResponse.from(noise.getAddress());
 		return builder()
 			.id(noise.getId())
-			.address(addressResponse)
+			.author(noise.getUser().getNickname())
 			.avgDecibel(noise.getAvgDecibel())
 			.createdAt(formatter.format(noise.getCreatedAt()))
 			.build();

--- a/soridam-common/src/main/java/sorisoop/soridam/common/response/SliceResponse.java
+++ b/soridam-common/src/main/java/sorisoop/soridam/common/response/SliceResponse.java
@@ -7,13 +7,13 @@ import lombok.Builder;
 @Builder
 public record SliceResponse<T>(
 	List<T> contents,
-	Long lastId,
+	String lastValue,
 	boolean hasNext
 ) {
-	public static <T> SliceResponse<T> of(List<T> contents, Long lastId, boolean hasNext) {
+	public static <T> SliceResponse<T> of(List<T> contents, String lastValue, boolean hasNext) {
 		return SliceResponse.<T>builder()
 			.contents(contents)
-			.lastId(lastId)
+			.lastValue(lastValue)
 			.hasNext(hasNext)
 			.build();
 	}

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/noise/application/NoiseQueryService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/noise/application/NoiseQueryService.java
@@ -2,7 +2,7 @@ package sorisoop.soridam.domain.noise.application;
 
 import java.util.List;
 
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -15,8 +15,10 @@ import sorisoop.soridam.domain.noise.exception.NoiseNotFoundException;
 public class NoiseQueryService {
 	private final NoiseRepository noiseRepository;
 
-	public List<Noise> getDetailNoise(Long addressId, Long lastId, Pageable pageable) {
-		return noiseRepository.findByAddressIdWithCursor(addressId, lastId, pageable);
+	public List<Noise> getByAddressWithCursorAndAvgDecibelRange(Long addressId, String lastValue, int minAvg, int maxAvg, int limit, Sort sort) {
+		return noiseRepository.findByAddressWithCursorAndAvgDecibelRange(
+			addressId, lastValue, minAvg, maxAvg, limit, sort
+		);
 	}
 
 	public Noise getById(Long id) {

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/noise/domain/NoiseLevel.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/noise/domain/NoiseLevel.java
@@ -1,16 +1,25 @@
 package sorisoop.soridam.domain.noise.domain;
 
+import java.util.Arrays;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public enum NoiseLevel {
-	QUIET(0, 70, "조용함"),
-	NORMAL(70, 100, "보통"),
-	LOUD(100, 120, "시끄러움");
+	QUIET(0, 50, "조용함"),
+	NORMAL(51, 70, "보통"),
+	LOUD(71, 120, "시끄러움");
 
 	private final int minDecibel;
 	private final int maxDecibel;
 	private final String description;
+
+	public static NoiseLevel from(int decibel) {
+		return Arrays.stream(values())
+			.filter(level -> decibel >= level.minDecibel && decibel <= level.maxDecibel)
+			.findFirst()
+			.orElse(LOUD);
+	}
 }

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/noise/domain/NoiseRepository.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/noise/domain/NoiseRepository.java
@@ -3,7 +3,7 @@ package sorisoop.soridam.domain.noise.domain;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 public interface NoiseRepository {
 	Optional<Noise> findById(Long id);
@@ -14,5 +14,5 @@ public interface NoiseRepository {
 
 	List<Noise> findByUserId(Long userId);
 
-	List<Noise> findByAddressIdWithCursor(Long addressId, Long lastId, Pageable pageable);
+	List<Noise> findByAddressWithCursorAndAvgDecibelRange(Long addressId, String lastValue, int minAvg, int maxAvg, int limit, Sort sort);
 }

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/impl/NoiseRepositoryImpl.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/impl/NoiseRepositoryImpl.java
@@ -3,18 +3,20 @@ package sorisoop.soridam.infra.repository.impl;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
 import sorisoop.soridam.domain.noise.domain.Noise;
 import sorisoop.soridam.domain.noise.domain.NoiseRepository;
 import sorisoop.soridam.infra.repository.jpa.JpaNoiseRepository;
+import sorisoop.soridam.infra.repository.jpa.QueryNoiseRepository;
 
 @Repository
 @RequiredArgsConstructor
 public class NoiseRepositoryImpl implements NoiseRepository {
 	private final JpaNoiseRepository jpaNoiseRepository;
+	private final QueryNoiseRepository queryNoiseRepository;
 
 	@Override
 	public Optional<Noise> findById(Long id) {
@@ -37,7 +39,17 @@ public class NoiseRepositoryImpl implements NoiseRepository {
 	}
 
 	@Override
-	public List<Noise> findByAddressIdWithCursor(Long addressId, Long lastId, Pageable pageable) {
-		return jpaNoiseRepository.findByAddressIdWithCursor(addressId, lastId, pageable);
+	public List<Noise> findByAddressWithCursorAndAvgDecibelRange(
+		Long addressId,
+		String lastValue,
+		int minAvg,
+		int maxAvg,
+		int limit,
+		Sort sort
+	) {
+		return queryNoiseRepository.findByAddressWithCursorAndAvgDecibelRange(
+			addressId, lastValue, minAvg, maxAvg, limit, sort
+		);
 	}
+
 }

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/jpa/QueryNoiseRepository.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/jpa/QueryNoiseRepository.java
@@ -1,0 +1,91 @@
+package sorisoop.soridam.infra.repository.jpa;
+
+import static com.querydsl.core.types.Order.ASC;
+import static com.querydsl.core.types.Order.DESC;
+import static sorisoop.soridam.domain.noise.domain.QNoise.noise;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import sorisoop.soridam.domain.noise.domain.Noise;
+
+@Repository
+@RequiredArgsConstructor
+public class QueryNoiseRepository {
+	private final JPAQueryFactory queryFactory;
+	private static final PathBuilder<Noise> noisePath = new PathBuilder<>(Noise.class, "noise");
+
+	public List<Noise> findByAddressWithCursorAndAvgDecibelRange(
+		Long addressId,
+		String lastValue,
+		int minAvg,
+		int maxAvg,
+		int limit,
+		Sort sort
+	) {
+		BooleanBuilder builder = new BooleanBuilder();
+
+		builder.and(noise.address.id.eq(addressId));
+		builder.and(noise.avgDecibel.between(minAvg, maxAvg));
+
+		if (lastValue != null) {
+			applyCursorCondition(builder, lastValue, sort);
+		}
+
+		return queryFactory.selectFrom(noise)
+			.where(builder)
+			.orderBy(convertSort(sort))
+			.limit(limit)
+			.fetch();
+	}
+
+	private void applyCursorCondition(BooleanBuilder builder, String lastValue, Sort sort) {
+		for (Sort.Order order : sort) {
+			String property = order.getProperty();
+			boolean isAsc = order.isAscending();
+
+			switch (property) {
+				case "id" -> {
+					Long idCursor = Long.parseLong(lastValue);
+					builder.and(isAsc ? noise.id.gt(idCursor) : noise.id.lt(idCursor));
+				}
+				case "avgDecibel" -> {
+					Integer decibelCursor = Integer.parseInt(lastValue);
+					builder.and(isAsc ? noise.avgDecibel.gt(decibelCursor) : noise.avgDecibel.lt(decibelCursor));
+				}
+				default -> throw new IllegalArgumentException("지원하지 않는 정렬 필드입니다: " + property);
+			}
+		}
+	}
+
+	private OrderSpecifier<?>[] convertSort(Sort sort) {
+		List<OrderSpecifier<?>> orders = new ArrayList<>();
+
+		for (Sort.Order order : sort) {
+			OrderSpecifier<?> specifier = new OrderSpecifier<>(
+				order.isAscending() ? ASC : DESC,
+				noisePath.getComparable(order.getProperty(), Comparable.class)
+			);
+			orders.add(specifier);
+		}
+
+		boolean sortedByAvg = sort.stream()
+			.anyMatch(order -> order.getProperty().equals("avgDecibel"));
+
+		if (sortedByAvg) {
+			orders.add(new OrderSpecifier<>(DESC, noise.id));
+		}
+
+		return orders.toArray(new OrderSpecifier[0]);
+	}
+
+}


### PR DESCRIPTION
## Summary

- 소음 데이터를 정렬 및 필터링할 수 있도록 기능을 확장했습니다.
- 정렬 필드는 `id`, `avgDecibel` 기준으로, 정렬 방향은 ASC/DESC 지원됩니다.
- 평균 데시벨에 대한 필터링(min, max) 조건도 추가되어 사용자 맞춤 검색이 가능해졌습니다.

## Tasks

- `NoiseSortField`, `SortDirection` Enum 추가
- QueryDSL 기반 정렬 변환 로직(`convertSort`) 구현
- avgDecibel 정렬 시 보조 정렬(id DESC) 추가
- 정렬 기준에 따라 커서 조건 적용 (id, avgDecibel 모두 지원)
- Facade 및 Controller에서 요청 처리 로직 반영

## To Reviewer

- 커서 기반 정렬에서 복합 조건 적용이 필요하여 `OrderSpecifier` 로직 분리했습니다.
- 커서 처리 시 avgDecibel 정렬이면 → 보조 정렬으로 id DESC 추가합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 소음 데이터 조회 시 커서 기반 페이지네이션, 소음 레벨 필터, 다양한 정렬 옵션(평균 데시벨, ID, 오름/내림차순) 지원이 추가되었습니다.
  - 소음 응답에 소음 레벨(QUIET, NORMAL, LOUD) 정보가 포함됩니다.
  - 소음 요약 응답에서 주소 정보 대신 작성자 닉네임이 표시됩니다.

- **버그 수정**
  - 없음

- **리팩터**
  - 페이지네이션 방식이 커서 기반(String)으로 변경되어 더 유연한 데이터 조회가 가능합니다.
  - 소음 레벨, 정렬 필드 등 관련 enum 및 내부 로직이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->