### PR TITLE
feature/#135 리뷰, 장소에 대한 좋아요 api 구현

### DIFF
--- a/soridam-api/src/main/java/sorisoop/soridam/api/like/application/LikeFacade.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/like/application/LikeFacade.java
@@ -41,7 +41,7 @@ public class LikeFacade {
 		Map<Long, Long> likeCountMap = likeQueryService.getLikeCountMap(likeType, targetIds);
 
 		List<LikeInfoDto> results = targetIds.stream()
-			.map(id -> LikeInfoDto.of(id, likeCountMap.getOrDefault(id, 0L).intValue(), likedMap.getOrDefault(id, false)))
+			.map(id -> LikeInfoDto.of(id, likeCountMap.getOrDefault(id, 0L), likedMap.getOrDefault(id, false)))
 			.toList();
 
 		return LikeInfoListResponse.from(results);

--- a/soridam-api/src/main/java/sorisoop/soridam/api/like/application/LikeFacade.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/like/application/LikeFacade.java
@@ -1,0 +1,49 @@
+package sorisoop.soridam.api.like.application;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import sorisoop.soridam.api.like.presentation.response.LikeInfoListResponse;
+import sorisoop.soridam.domain.like.application.LikeCommandService;
+import sorisoop.soridam.domain.like.application.LikeQueryService;
+import sorisoop.soridam.domain.like.application.dto.LikeInfoDto;
+import sorisoop.soridam.domain.like.domain.LikeType;
+import sorisoop.soridam.domain.user.user.application.UserQueryService;
+import sorisoop.soridam.domain.user.user.domain.User;
+
+@Component
+@RequiredArgsConstructor
+public class LikeFacade {
+	private final LikeCommandService likeCommandService;
+	private final LikeQueryService likeQueryService;
+	private final UserQueryService userQueryService;
+
+	@Transactional
+	public boolean toggleLike(LikeType likeType, long targetId) {
+		User user = userQueryService.me();
+		return likeCommandService.toggleLike(user, likeType, targetId);
+	}
+
+	@Transactional(readOnly = true)
+	public LikeInfoDto getLikeInfo(LikeType likeType, long targetId) {
+		User user = userQueryService.me();
+		return likeQueryService.getLikeInfo(user, likeType, targetId);
+	}
+
+	@Transactional(readOnly = true)
+	public LikeInfoListResponse getLikedMap(LikeType likeType, List<Long> targetIds) {
+		User user = userQueryService.me();
+		Map<Long, Boolean> likedMap = likeQueryService.getLikedMap(user, likeType, targetIds);
+		Map<Long, Long> likeCountMap = likeQueryService.getLikeCountMap(likeType, targetIds);
+
+		List<LikeInfoDto> results = targetIds.stream()
+			.map(id -> LikeInfoDto.of(id, likeCountMap.getOrDefault(id, 0L).intValue(), likedMap.getOrDefault(id, false)))
+			.toList();
+
+		return LikeInfoListResponse.from(results);
+	}
+}

--- a/soridam-api/src/main/java/sorisoop/soridam/api/like/presentation/LikeApiController.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/like/presentation/LikeApiController.java
@@ -1,0 +1,66 @@
+package sorisoop.soridam.api.like.presentation;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import sorisoop.soridam.api.like.application.LikeFacade;
+import sorisoop.soridam.api.like.presentation.response.LikeInfoListResponse;
+import sorisoop.soridam.domain.like.application.dto.LikeInfoDto;
+import sorisoop.soridam.domain.like.domain.LikeType;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Like", description = "좋아요 API")
+@RequestMapping("/api/likes")
+public class LikeApiController {
+	private final LikeFacade likeFacade;
+
+	@Operation(summary = "좋아요 토글 API", description = "- Description : 해당 타겟에 대해 좋아요를 토글합니다.")
+	@ApiResponse(responseCode = "200", description = "토글 성공")
+	@PostMapping("/{likeType}/{targetId}")
+	public ResponseEntity<Boolean> toggleLike(
+		@Parameter(description = "좋아요 타입", example = "REVIEW", required = true)
+		@PathVariable LikeType likeType,
+		@Parameter(description = "타겟 ID", example = "1", required = true)
+		@PathVariable long targetId
+	) {
+		boolean liked = likeFacade.toggleLike(likeType, targetId);
+		return ResponseEntity.ok(liked);
+	}
+
+	@Operation(summary = "좋아요 정보 조회 API", description = "- Description : 특정 타겟에 대해 좋아요 수 및 좋아요 여부를 조회합니다.")
+	@ApiResponse(responseCode = "200", description = "조회 성공")
+	@GetMapping("/{likeType}/{targetId}")
+	public ResponseEntity<LikeInfoDto> getLikeInfo(
+		@Parameter(description = "좋아요 타입", example = "REVIEW", required = true)
+		@PathVariable LikeType likeType,
+		@Parameter(description = "타겟 ID", example = "1", required = true)
+		@PathVariable long targetId
+	) {
+		return ResponseEntity.ok(likeFacade.getLikeInfo(likeType, targetId));
+	}
+
+	@Operation(summary = "좋아요 리스트 정보 조회 API", description = "- Description : 여러 타겟 ID에 대한 좋아요 수 및 좋아요 여부를 조회합니다.")
+	@ApiResponse(responseCode = "200", description = "조회 성공")
+	@GetMapping("/batch")
+	public ResponseEntity<LikeInfoListResponse> getLikedMap(
+		@Parameter(description = "좋아요 타입", example = "REVIEW", required = true)
+		@RequestParam LikeType likeType,
+		@Parameter(description = "타겟 ID 리스트", example = "1,2,3", required = true)
+		@RequestParam List<Long> targetIds
+	) {
+		return ResponseEntity.ok(likeFacade.getLikedMap(likeType, targetIds));
+	}
+}

--- a/soridam-api/src/main/java/sorisoop/soridam/api/like/presentation/response/LikeInfoListResponse.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/like/presentation/response/LikeInfoListResponse.java
@@ -1,0 +1,17 @@
+package sorisoop.soridam.api.like.presentation.response;
+
+import java.util.List;
+
+import lombok.Builder;
+import sorisoop.soridam.domain.like.application.dto.LikeInfoDto;
+
+@Builder
+public record LikeInfoListResponse(
+	List<LikeInfoDto> responses
+) {
+	public static LikeInfoListResponse from(List<LikeInfoDto> responses) {
+		return LikeInfoListResponse.builder()
+			.responses(responses)
+			.build();
+	}
+}

--- a/soridam-api/src/main/resources/application.yml
+++ b/soridam-api/src/main/resources/application.yml
@@ -35,6 +35,7 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD}
+      timeout: 5000
 
 springdoc:
   default-consumes-media-type: application/json

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/LikeCommandService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/LikeCommandService.java
@@ -13,14 +13,14 @@ import sorisoop.soridam.domain.user.user.domain.User;
 public class LikeCommandService {
 	private final LikeRepository likeRepository;
 
-	public boolean toggleLike(User user, LikeType type, Long targetId) {
-		return likeRepository.findByUserAndLikeTypeAndTargetId(user, type, targetId)
+	public boolean toggleLike(User user, LikeType likeType, Long targetId) {
+		return likeRepository.findByUserAndLikeTypeAndTargetId(user, likeType, targetId)
 			.map(existingLike -> {
 				likeRepository.delete(existingLike);
 				return false;
 			})
 			.orElseGet(() -> {
-				Like like = Like.create(user, type, targetId);
+				Like like = Like.create(user, likeType, targetId);
 				likeRepository.save(like);
 				return true;
 			});

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/LikeCommandService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/LikeCommandService.java
@@ -1,0 +1,29 @@
+package sorisoop.soridam.domain.like.application;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import sorisoop.soridam.domain.like.domain.Like;
+import sorisoop.soridam.domain.like.domain.LikeRepository;
+import sorisoop.soridam.domain.like.domain.LikeType;
+import sorisoop.soridam.domain.user.user.domain.User;
+
+@Service
+@RequiredArgsConstructor
+public class LikeCommandService {
+	private final LikeRepository likeRepository;
+
+	public boolean toggleLike(User user, LikeType type, Long targetId) {
+		return likeRepository.findByUserAndLikeTypeAndTargetId(user, type, targetId)
+			.map(existingLike -> {
+				likeRepository.delete(existingLike);
+				return false;
+			})
+			.orElseGet(() -> {
+				Like like = Like.create(user, type, targetId);
+				likeRepository.save(like);
+				return true;
+			});
+	}
+}
+

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/LikeQueryService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/LikeQueryService.java
@@ -21,7 +21,7 @@ public class LikeQueryService {
 	private final LikeRepository likeRepository;
 
 	public LikeInfoDto getLikeInfo(User user, LikeType likeType, long targetId) {
-		int likeCount = likeRepository.countByLikeTypeAndTargetId(likeType, targetId);
+		long likeCount = likeRepository.countByLikeTypeAndTargetId(likeType, targetId);
 		boolean liked = likeRepository.existsByUserAndLikeTypeAndTargetId(user, likeType, targetId);
 
 		return LikeInfoDto.of(targetId, likeCount, liked);

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/LikeQueryService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/LikeQueryService.java
@@ -24,7 +24,7 @@ public class LikeQueryService {
 		int likeCount = likeRepository.countByLikeTypeAndTargetId(type, targetId);
 		boolean liked = likeRepository.existsByUserAndLikeTypeAndTargetId(user, type, targetId);
 
-		return new LikeInfoDto(targetId, likeCount, liked);
+		return LikeInfoDto.of(targetId, likeCount, liked);
 	}
 
 

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/LikeQueryService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/LikeQueryService.java
@@ -20,9 +20,9 @@ import sorisoop.soridam.domain.user.user.domain.User;
 public class LikeQueryService {
 	private final LikeRepository likeRepository;
 
-	public LikeInfoDto getLikeInfo(User user, LikeType type, long targetId) {
-		int likeCount = likeRepository.countByLikeTypeAndTargetId(type, targetId);
-		boolean liked = likeRepository.existsByUserAndLikeTypeAndTargetId(user, type, targetId);
+	public LikeInfoDto getLikeInfo(User user, LikeType likeType, long targetId) {
+		int likeCount = likeRepository.countByLikeTypeAndTargetId(likeType, targetId);
+		boolean liked = likeRepository.existsByUserAndLikeTypeAndTargetId(user, likeType, targetId);
 
 		return LikeInfoDto.of(targetId, likeCount, liked);
 	}

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/LikeQueryService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/LikeQueryService.java
@@ -1,0 +1,50 @@
+package sorisoop.soridam.domain.like.application;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import sorisoop.soridam.domain.like.application.dto.LikeCountDto;
+import sorisoop.soridam.domain.like.application.dto.LikeInfoDto;
+import sorisoop.soridam.domain.like.domain.Like;
+import sorisoop.soridam.domain.like.domain.LikeRepository;
+import sorisoop.soridam.domain.like.domain.LikeType;
+import sorisoop.soridam.domain.user.user.domain.User;
+
+@Service
+@RequiredArgsConstructor
+public class LikeQueryService {
+	private final LikeRepository likeRepository;
+
+	// LikeQueryService 내부에 추가
+	public LikeInfoDto getLikeInfo(User user, LikeType type, long targetId) {
+		int likeCount = likeRepository.countByLikeTypeAndTargetId(type, targetId);
+		boolean liked = likeRepository.existsByUserAndLikeTypeAndTargetId(user, type, targetId);
+
+		return new LikeInfoDto(targetId, likeCount, liked);
+	}
+
+
+	public Map<Long, Boolean> getLikedMap(User user, LikeType likeType, List<Long> targetIds) {
+		List<Like> likes = likeRepository.findByUserAndLikeTypeAndTargetIdIn(user, likeType, targetIds);
+		Set<Long> likedIds = likes.stream()
+			.map(Like::getTargetId)
+			.collect(Collectors.toSet());
+
+		return targetIds.stream()
+			.collect(Collectors.toMap(
+				id -> id,
+				likedIds::contains
+			));
+	}
+
+	public Map<Long, Long> getLikeCountMap(LikeType likeType, List<Long> targetIds) {
+		List<LikeCountDto> results = likeRepository.countByLikeTypeGroupByTargetId(likeType, targetIds);
+		return results.stream()
+			.collect(Collectors.toMap(LikeCountDto::targetId, LikeCountDto::count));
+	}
+}

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/LikeQueryService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/LikeQueryService.java
@@ -20,7 +20,6 @@ import sorisoop.soridam.domain.user.user.domain.User;
 public class LikeQueryService {
 	private final LikeRepository likeRepository;
 
-	// LikeQueryService 내부에 추가
 	public LikeInfoDto getLikeInfo(User user, LikeType type, long targetId) {
 		int likeCount = likeRepository.countByLikeTypeAndTargetId(type, targetId);
 		boolean liked = likeRepository.existsByUserAndLikeTypeAndTargetId(user, type, targetId);

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/dto/LikeCountDto.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/dto/LikeCountDto.java
@@ -1,0 +1,7 @@
+package sorisoop.soridam.domain.like.application.dto;
+
+public record LikeCountDto(
+	Long targetId,
+	Long count
+) {}
+

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/dto/LikeInfoDto.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/dto/LikeInfoDto.java
@@ -1,7 +1,18 @@
 package sorisoop.soridam.domain.like.application.dto;
 
+import lombok.Builder;
+
+@Builder
 public record LikeInfoDto(
 	long targetId,
 	int likeCount,
 	boolean liked
-) {}
+) {
+	public static LikeInfoDto of(long targetId, int likeCount, boolean liked) {
+		return LikeInfoDto.builder()
+			.targetId(targetId)
+			.likeCount(likeCount)
+			.liked(liked)
+			.build();
+	}
+}

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/dto/LikeInfoDto.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/dto/LikeInfoDto.java
@@ -5,10 +5,10 @@ import lombok.Builder;
 @Builder
 public record LikeInfoDto(
 	long targetId,
-	int likeCount,
+	long likeCount,
 	boolean liked
 ) {
-	public static LikeInfoDto of(long targetId, int likeCount, boolean liked) {
+	public static LikeInfoDto of(long targetId, long likeCount, boolean liked) {
 		return LikeInfoDto.builder()
 			.targetId(targetId)
 			.likeCount(likeCount)

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/dto/LikeInfoDto.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/dto/LikeInfoDto.java
@@ -1,0 +1,7 @@
+package sorisoop.soridam.domain.like.application.dto;
+
+public record LikeInfoDto(
+	long targetId,
+	int likeCount,
+	boolean liked
+) {}

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/dto/LikeInfoDto.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/like/application/dto/LikeInfoDto.java
@@ -1,18 +1,11 @@
 package sorisoop.soridam.domain.like.application.dto;
 
-import lombok.Builder;
-
-@Builder
 public record LikeInfoDto(
 	long targetId,
 	long likeCount,
 	boolean liked
 ) {
 	public static LikeInfoDto of(long targetId, long likeCount, boolean liked) {
-		return LikeInfoDto.builder()
-			.targetId(targetId)
-			.likeCount(likeCount)
-			.liked(liked)
-			.build();
+		return new LikeInfoDto(targetId, likeCount, liked);
 	}
 }

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/like/domain/Like.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/like/domain/Like.java
@@ -27,7 +27,7 @@ import sorisoop.soridam.domain.user.user.domain.User;
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor(access = PROTECTED)
 @Table(name = "likes", uniqueConstraints = {
-	@UniqueConstraint(columnNames = {"user_id", "type", "target_id"})
+	@UniqueConstraint(columnNames = {"user_id", "like_type", "target_id"})
 })
 public class Like extends BaseTimeEntity {
 	@Id
@@ -39,7 +39,7 @@ public class Like extends BaseTimeEntity {
 	private User user;
 
 	@Enumerated(STRING)
-	@Column(nullable = false)
+	@Column(nullable = false, name = "like_type")
 	private LikeType likeType;
 
 	@Column(nullable = false, name = "target_id")

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/like/domain/Like.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/like/domain/Like.java
@@ -1,0 +1,37 @@
+package sorisoop.soridam.domain.like.domain;
+
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sorisoop.soridam.domain.common.BaseTimeEntity;
+import sorisoop.soridam.domain.user.user.domain.User;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor(access = PROTECTED)
+public class Like extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = LAZY)
+	private User user;
+
+	@Enumerated(STRING)
+	private LikeType likeType;
+
+	private Long targetId;
+}

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/like/domain/Like.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/like/domain/Like.java
@@ -5,11 +5,15 @@ import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,16 +26,30 @@ import sorisoop.soridam.domain.user.user.domain.User;
 @Builder
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor(access = PROTECTED)
+@Table(name = "likes", uniqueConstraints = {
+	@UniqueConstraint(columnNames = {"user_id", "type", "target_id"})
+})
 public class Like extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = IDENTITY)
 	private Long id;
 
 	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "user_id")
 	private User user;
 
 	@Enumerated(STRING)
+	@Column(nullable = false)
 	private LikeType likeType;
 
+	@Column(nullable = false, name = "target_id")
 	private Long targetId;
+
+	public static Like create(User user, LikeType likeType, Long targetId) {
+		return Like.builder()
+			.user(user)
+			.likeType(likeType)
+			.targetId(targetId)
+			.build();
+	}
 }

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/like/domain/LikeRepository.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/like/domain/LikeRepository.java
@@ -7,7 +7,7 @@ import sorisoop.soridam.domain.like.application.dto.LikeCountDto;
 import sorisoop.soridam.domain.user.user.domain.User;
 
 public interface LikeRepository {
-	int countByLikeTypeAndTargetId(LikeType type, long targetId);
+	long countByLikeTypeAndTargetId(LikeType type, long targetId);
 
 	List<Like> findByUserAndLikeTypeAndTargetIdIn(User user, LikeType likeType, List<Long> targetIds);
 

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/like/domain/LikeRepository.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/like/domain/LikeRepository.java
@@ -1,6 +1,7 @@
 package sorisoop.soridam.domain.like.domain;
 
 import java.util.List;
+import java.util.Optional;
 
 import sorisoop.soridam.domain.like.application.dto.LikeCountDto;
 import sorisoop.soridam.domain.user.user.domain.User;
@@ -13,4 +14,10 @@ public interface LikeRepository {
 	List<LikeCountDto> countByLikeTypeGroupByTargetId(LikeType likeType, List<Long> targetIds);
 
 	boolean existsByUserAndLikeTypeAndTargetId(User user, LikeType type, long targetId);
+
+	void delete(Like like);
+
+	void save(Like like);
+
+	Optional<Like> findByUserAndLikeTypeAndTargetId(User user, LikeType type, Long targetId);
 }

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/like/domain/LikeRepository.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/like/domain/LikeRepository.java
@@ -1,4 +1,16 @@
 package sorisoop.soridam.domain.like.domain;
 
+import java.util.List;
+
+import sorisoop.soridam.domain.like.application.dto.LikeCountDto;
+import sorisoop.soridam.domain.user.user.domain.User;
+
 public interface LikeRepository {
+	int countByLikeTypeAndTargetId(LikeType type, long targetId);
+
+	List<Like> findByUserAndLikeTypeAndTargetIdIn(User user, LikeType likeType, List<Long> targetIds);
+
+	List<LikeCountDto> countByLikeTypeGroupByTargetId(LikeType likeType, List<Long> targetIds);
+
+	boolean existsByUserAndLikeTypeAndTargetId(User user, LikeType type, long targetId);
 }

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/like/domain/LikeRepository.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/like/domain/LikeRepository.java
@@ -1,0 +1,4 @@
+package sorisoop.soridam.domain.like.domain;
+
+public interface LikeRepository {
+}

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/like/domain/LikeType.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/like/domain/LikeType.java
@@ -1,6 +1,14 @@
 package sorisoop.soridam.domain.like.domain;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum LikeType {
-	REVIEW,
-	PLACE
+	REVIEW("리뷰"),
+	PLACE("장소"),
+	;
+
+	private final String description;
 }

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/like/domain/LikeType.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/like/domain/LikeType.java
@@ -1,0 +1,6 @@
+package sorisoop.soridam.domain.like.domain;
+
+public enum LikeType {
+	REVIEW,
+	PLACE
+}

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/config/data/redis/RedisConfig.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/config/data/redis/RedisConfig.java
@@ -11,6 +11,7 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -42,8 +43,8 @@ public class RedisConfig {
 	}
 
 	@Bean
-	public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
-		RedisTemplate<String, String> template = new RedisTemplate<>();
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
 		template.setConnectionFactory(connectionFactory);
 		template.setKeySerializer(new StringRedisSerializer());
 		template.setHashKeySerializer(new StringRedisSerializer());
@@ -53,5 +54,10 @@ public class RedisConfig {
 		template.afterPropertiesSet();
 
 		return template;
+	}
+
+	@Bean
+	public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+		return new StringRedisTemplate(connectionFactory);
 	}
 }

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/config/data/redis/RedisConfig.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/config/data/redis/RedisConfig.java
@@ -2,7 +2,8 @@ package sorisoop.soridam.infra.config.data.redis;
 
 import java.time.Duration;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -14,27 +15,24 @@ import org.springframework.data.redis.repository.configuration.EnableRedisReposi
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import lombok.RequiredArgsConstructor;
+
 @Configuration
 @EnableRedisRepositories(basePackages = "sorisoop.soridam.infra.repository.redis")
+@EnableConfigurationProperties(RedisProperties.class)
+@RequiredArgsConstructor
 public class RedisConfig {
-	@Value("${spring.data.redis.host}")
-	String redisHost;
-
-	@Value("${spring.data.redis.port}")
-	int redisPort;
-
-	@Value("${spring.data.redis.password}")
-	String redisPassword;
+	private final RedisProperties redisProperties;
 
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
 		RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
-		configuration.setHostName(redisHost);
-		configuration.setPort(redisPort);
-		configuration.setPassword(redisPassword);
+		configuration.setHostName(redisProperties.getHost());
+		configuration.setPort(redisProperties.getPort());
+		configuration.setPassword(redisProperties.getPassword());
 
 		LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
-			.commandTimeout(Duration.ofSeconds(5))
+			.commandTimeout(redisProperties.getTimeout())
 			.shutdownTimeout(Duration.ofSeconds(2))
 			.build();
 

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/impl/LikeRepositoryImpl.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/impl/LikeRepositoryImpl.java
@@ -1,13 +1,39 @@
 package sorisoop.soridam.infra.repository.impl;
 
+import java.util.List;
+
 import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
+import sorisoop.soridam.domain.like.application.dto.LikeCountDto;
+import sorisoop.soridam.domain.like.domain.Like;
 import sorisoop.soridam.domain.like.domain.LikeRepository;
+import sorisoop.soridam.domain.like.domain.LikeType;
+import sorisoop.soridam.domain.user.user.domain.User;
 import sorisoop.soridam.infra.repository.jpa.JpaLikeRepository;
 
 @Repository
 @RequiredArgsConstructor
 public class LikeRepositoryImpl implements LikeRepository {
 	private final JpaLikeRepository jpaLikeRepository;
+
+	@Override
+	public int countByLikeTypeAndTargetId(LikeType type, long targetId) {
+		return jpaLikeRepository.countByLikeTypeAndTargetId(type, targetId);
+	}
+
+	@Override
+	public List<Like> findByUserAndLikeTypeAndTargetIdIn(User user, LikeType likeType, List<Long> targetIds) {
+		return jpaLikeRepository.findByUserAndLikeTypeAndTargetIdIn(user, likeType, targetIds);
+	}
+
+	@Override
+	public List<LikeCountDto> countByLikeTypeGroupByTargetId(LikeType likeType, List<Long> targetIds) {
+		return jpaLikeRepository.countByLikeTypeGroupByTargetId(likeType, targetIds);
+	}
+
+	@Override
+	public boolean existsByUserAndLikeTypeAndTargetId(User user, LikeType likeType, long targetId) {
+		return jpaLikeRepository.existsByUserAndLikeTypeAndTargetId(user, likeType, targetId);
+	}
 }

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/impl/LikeRepositoryImpl.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/impl/LikeRepositoryImpl.java
@@ -1,6 +1,7 @@
 package sorisoop.soridam.infra.repository.impl;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
@@ -35,5 +36,20 @@ public class LikeRepositoryImpl implements LikeRepository {
 	@Override
 	public boolean existsByUserAndLikeTypeAndTargetId(User user, LikeType likeType, long targetId) {
 		return jpaLikeRepository.existsByUserAndLikeTypeAndTargetId(user, likeType, targetId);
+	}
+
+	@Override
+	public void delete(Like like) {
+		jpaLikeRepository.delete(like);
+	}
+
+	@Override
+	public void save(Like like) {
+		jpaLikeRepository.save(like);
+	}
+
+	@Override
+	public Optional<Like> findByUserAndLikeTypeAndTargetId(User user, LikeType likeType, Long targetId) {
+		return jpaLikeRepository.findByUserAndLikeTypeAndTargetId(user, likeType, targetId);
 	}
 }

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/impl/LikeRepositoryImpl.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/impl/LikeRepositoryImpl.java
@@ -1,0 +1,13 @@
+package sorisoop.soridam.infra.repository.impl;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import sorisoop.soridam.domain.like.domain.LikeRepository;
+import sorisoop.soridam.infra.repository.jpa.JpaLikeRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class LikeRepositoryImpl implements LikeRepository {
+	private final JpaLikeRepository jpaLikeRepository;
+}

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/impl/LikeRepositoryImpl.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/impl/LikeRepositoryImpl.java
@@ -19,7 +19,7 @@ public class LikeRepositoryImpl implements LikeRepository {
 	private final JpaLikeRepository jpaLikeRepository;
 
 	@Override
-	public int countByLikeTypeAndTargetId(LikeType type, long targetId) {
+	public long countByLikeTypeAndTargetId(LikeType type, long targetId) {
 		return jpaLikeRepository.countByLikeTypeAndTargetId(type, targetId);
 	}
 

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/jpa/JpaLikeRepository.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/jpa/JpaLikeRepository.java
@@ -1,8 +1,25 @@
 package sorisoop.soridam.infra.repository.jpa;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import sorisoop.soridam.domain.like.application.dto.LikeCountDto;
 import sorisoop.soridam.domain.like.domain.Like;
+import sorisoop.soridam.domain.like.domain.LikeType;
+import sorisoop.soridam.domain.user.user.domain.User;
 
 public interface JpaLikeRepository extends JpaRepository<Like, Long> {
+	int countByLikeTypeAndTargetId(LikeType type, long targetId);
+
+	List<Like> findByUserAndLikeTypeAndTargetIdIn(User user, LikeType likeType, List<Long> targetIds);
+
+	@Query("SELECT new sorisoop.soridam.domain.like.application.dto.LikeCountDto(l.targetId, COUNT(l)) "
+		+ "FROM Like l "
+		+ "WHERE l.likeType = :likeType AND l.targetId IN :targetIds "
+		+ "GROUP BY l.targetId")
+	List<LikeCountDto> countByLikeTypeGroupByTargetId(LikeType likeType, List<Long> targetIds);
+
+	boolean existsByUserAndLikeTypeAndTargetId(User user, LikeType likeType, long targetId);
 }

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/jpa/JpaLikeRepository.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/jpa/JpaLikeRepository.java
@@ -1,0 +1,8 @@
+package sorisoop.soridam.infra.repository.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import sorisoop.soridam.domain.like.domain.Like;
+
+public interface JpaLikeRepository extends JpaRepository<Like, Long> {
+}

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/jpa/JpaLikeRepository.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/jpa/JpaLikeRepository.java
@@ -12,7 +12,7 @@ import sorisoop.soridam.domain.like.domain.LikeType;
 import sorisoop.soridam.domain.user.user.domain.User;
 
 public interface JpaLikeRepository extends JpaRepository<Like, Long> {
-	int countByLikeTypeAndTargetId(LikeType type, long targetId);
+	long countByLikeTypeAndTargetId(LikeType type, long targetId);
 
 	List<Like> findByUserAndLikeTypeAndTargetIdIn(User user, LikeType likeType, List<Long> targetIds);
 

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/jpa/JpaLikeRepository.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/jpa/JpaLikeRepository.java
@@ -1,9 +1,12 @@
 package sorisoop.soridam.infra.repository.jpa;
 
+import static jakarta.persistence.LockModeType.PESSIMISTIC_WRITE;
+
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
 import sorisoop.soridam.domain.like.application.dto.LikeCountDto;
@@ -24,5 +27,6 @@ public interface JpaLikeRepository extends JpaRepository<Like, Long> {
 
 	boolean existsByUserAndLikeTypeAndTargetId(User user, LikeType likeType, long targetId);
 
+	@Lock(PESSIMISTIC_WRITE)
 	Optional<Like> findByUserAndLikeTypeAndTargetId(User user, LikeType likeType, Long targetId);
 }

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/jpa/JpaLikeRepository.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/jpa/JpaLikeRepository.java
@@ -1,6 +1,7 @@
 package sorisoop.soridam.infra.repository.jpa;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -22,4 +23,6 @@ public interface JpaLikeRepository extends JpaRepository<Like, Long> {
 	List<LikeCountDto> countByLikeTypeGroupByTargetId(LikeType likeType, List<Long> targetIds);
 
 	boolean existsByUserAndLikeTypeAndTargetId(User user, LikeType likeType, long targetId);
+
+	Optional<Like> findByUserAndLikeTypeAndTargetId(User user, LikeType likeType, Long targetId);
 }


### PR DESCRIPTION
## Summary

>- close #135 

- 리뷰 및 장소에 대한 좋아요 기능을 구현했습니다.
- 사용자 기준으로 좋아요 토글 및 좋아요 수/여부 조회 기능을 제공합니다.

## Tasks

- 좋아요 도메인, 서비스, 파사드 레이어 구성
- 좋아요 수 + 여부 동시 조회를 위한 API 구현 (`LikeInfoDto`, `LikeInfoListResponse`)
- GET `/api/likes/{type}/{targetId}` - 좋아요 토글 API
- POST `/api/likes/{type}/{targetId}` - 단일 대상 좋아요 조회 API
- GET `/api/likes/batch` - 다중 대상 좋아요 정보 일괄 조회 API

## To Reviewer

- `LikeType`으로 확장 가능하게 설계했으며, 현재는 `REVIEW`, `PLACE` 두 가지 타입을 지원합니다.
- 이후 작업으로는 다음 기능이 예정되어 있습니다:
  - 좋아요가 눌린 경우, 해당 리뷰 작성자에게 알림 전송
  - 좋아요 수를 컬럼 기반으로 관리하여 조회 성능 최적화
  - 동시성 이슈 방지를 위한 처리 로직 적용 (예: 비관적 락)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 리뷰 및 장소에 대한 좋아요(Like) 기능이 추가되었습니다.
    - 좋아요 상태를 토글(추가/취소)할 수 있는 API가 제공됩니다.
    - 특정 대상의 좋아요 수와 내가 좋아요를 눌렀는지 확인할 수 있습니다.
    - 여러 대상에 대한 좋아요 정보를 한 번에 조회할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->