### PR TITLE
feature/#152 유사 사용자 및 위치 기반 추천 기능 추가

### DIFF
--- a/soridam-api/src/main/java/sorisoop/soridam/api/place/application/PlaceFacade.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/place/application/PlaceFacade.java
@@ -90,10 +90,10 @@ public class PlaceFacade {
 	}
 
 	@Transactional(readOnly = true)
-	public PlaceListResponse getRecommendedPlaces(double lat, double lon) throws IOException {
+	public PlaceListResponse getRecommendedPlaces(double lat, double lon, int size) throws IOException {
 		User user = userQueryService.me();
 
-		List<Long> recommendPlacesIdsForUser = placeRecommendationService.recommendPlacesForUser(user.getId(), lat, lon, 10);
+		List<Long> recommendPlacesIdsForUser = placeRecommendationService.recommendPlacesForUser(user.getId(), lat, lon, size);
 		List<PlaceResponse> recommendedPlaces = placeQueryService.getAllById(recommendPlacesIdsForUser).stream()
 			.map(PlaceResponse::from)
 			.toList();

--- a/soridam-api/src/main/java/sorisoop/soridam/api/place/application/PlaceFacade.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/place/application/PlaceFacade.java
@@ -2,6 +2,7 @@ package sorisoop.soridam.api.place.application;
 
 import static sorisoop.soridam.domain.activitylog.domain.enums.ActivityType.VIEW;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.springframework.stereotype.Component;
@@ -16,6 +17,7 @@ import sorisoop.soridam.api.place.presentation.response.PlaceResponse;
 import sorisoop.soridam.domain.activitylog.application.ActivityLogService;
 import sorisoop.soridam.domain.place.place.application.PlaceCommandService;
 import sorisoop.soridam.domain.place.place.application.PlaceQueryService;
+import sorisoop.soridam.domain.place.place.application.PlaceRecommendationService;
 import sorisoop.soridam.domain.place.place.domain.Place;
 import sorisoop.soridam.domain.place.place.domain.enums.Category;
 import sorisoop.soridam.domain.user.user.application.UserQueryService;
@@ -27,6 +29,7 @@ import sorisoop.soridam.infra.repository.redis.SummaryCacheService;
 public class PlaceFacade {
 	private final PlaceQueryService placeQueryService;
 	private final PlaceCommandService placeCommandService;
+	private final PlaceRecommendationService placeRecommendationService;
 	private final SummaryCacheService summaryCacheService;
 	private final UserQueryService userQueryService;
 	private final ActivityLogService activityLogService;
@@ -87,10 +90,14 @@ public class PlaceFacade {
 	}
 
 	@Transactional(readOnly = true)
-	public PlaceListResponse getRecommendedPlaces(double x, double y) {
+	public PlaceListResponse getRecommendedPlaces(double lat, double lon) throws IOException {
 		User user = userQueryService.me();
-		List<PlaceResponse> recommendedPlaces = placeQueryService.getRecommendedPlaces(x, y, user).stream()
+
+		List<Long> recommendPlacesIdsForUser = placeRecommendationService.recommendPlacesForUser(user.getId(), lat, lon, 10);
+		List<PlaceResponse> recommendedPlaces = placeQueryService.getAllById(recommendPlacesIdsForUser).stream()
 			.map(PlaceResponse::from)
 			.toList();
+
+		return PlaceListResponse.of(recommendedPlaces);
 	}
 }

--- a/soridam-api/src/main/java/sorisoop/soridam/api/place/application/PlaceFacade.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/place/application/PlaceFacade.java
@@ -85,4 +85,12 @@ public class PlaceFacade {
 
 		return PlacePersistResponse.from(place);
 	}
+
+	@Transactional(readOnly = true)
+	public PlaceListResponse getRecommendedPlaces(double x, double y) {
+		User user = userQueryService.me();
+		List<PlaceResponse> recommendedPlaces = placeQueryService.getRecommendedPlaces(x, y, user).stream()
+			.map(PlaceResponse::from)
+			.toList();
+	}
 }

--- a/soridam-api/src/main/java/sorisoop/soridam/api/place/presentation/PlaceApiController.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/place/presentation/PlaceApiController.java
@@ -122,8 +122,11 @@ public class PlaceApiController {
 		double lon,
 
 		@RequestParam @Parameter(description = "현재 위치 Y 좌표 (latitude)", example = "37.12345", required = true)
-		double lat
+		double lat,
+
+		@RequestParam(defaultValue = "10") @Parameter(description = "장소 개수", example = "10")
+		int size
 	) throws IOException {
-		return ResponseEntity.ok(placeFacade.getRecommendedPlaces(lat, lon));
+		return ResponseEntity.ok(placeFacade.getRecommendedPlaces(lat, lon, size));
 	}
 }

--- a/soridam-api/src/main/java/sorisoop/soridam/api/place/presentation/PlaceApiController.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/place/presentation/PlaceApiController.java
@@ -2,6 +2,7 @@ package sorisoop.soridam.api.place.presentation;
 
 import static org.springframework.http.HttpStatus.CREATED;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
@@ -112,5 +113,17 @@ public class PlaceApiController {
 	) {
 		kakaoPlaceService.importPlacesForAllRegions();
 		return ResponseEntity.ok().build();
+	}
+
+	@Operation(summary = "사용자 활동 기반 장소 추천")
+	@GetMapping("/recommend")
+	public ResponseEntity<PlaceListResponse> getRecommendPlaces(
+		@RequestParam @Parameter(description = "현재 위치 X 좌표 (longitude)", example = "127.12345", required = true)
+		double lon,
+
+		@RequestParam @Parameter(description = "현재 위치 Y 좌표 (latitude)", example = "37.12345", required = true)
+		double lat
+	) throws IOException {
+		return ResponseEntity.ok(placeFacade.getRecommendedPlaces(lat, lon));
 	}
 }

--- a/soridam-api/src/main/java/sorisoop/soridam/api/review/application/ReviewFacade.java
+++ b/soridam-api/src/main/java/sorisoop/soridam/api/review/application/ReviewFacade.java
@@ -49,7 +49,7 @@ public class ReviewFacade {
 
 		ReviewCreatedEvent event = ReviewCreatedEvent.from(review);
 		notificationAsyncService.sendReviewNotification(event);
-		activityLogService.save(author, place, REVIEW);
+		activityLogService.save(author, place, REVIEW, request.tags());
 		return ReviewPersistResponse.from(review);
 	}
 

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/activitylog/application/ActivityLogService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/activitylog/application/ActivityLogService.java
@@ -21,21 +21,7 @@ public class ActivityLogService {
 
 	@Async("activityLogExecutor")
 	public void save(User user, Place place, ActivityType activityType) {
-		if (validateAndLogInput(user, place, activityType)) return;
-
-		double[] coords = extractCoordinates(place);
-		double lon = coords[0];
-		double lat = coords[1];
-
-		ActivityLog activityLog = ActivityLog.create(
-			user.getId(),
-			place.getId(),
-			lat,
-			lon,
-			activityType
-		);
-
-		activityLogRepository.save(activityLog);
+		save(user, place, activityType, Set.of());
 	}
 
 	@Async("activityLogExecutor")

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/activitylog/application/ActivityLogService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/activitylog/application/ActivityLogService.java
@@ -1,5 +1,7 @@
 package sorisoop.soridam.domain.activitylog.application;
 
+import java.util.Set;
+
 import org.locationtech.jts.geom.Point;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -9,6 +11,7 @@ import sorisoop.soridam.domain.activitylog.domain.ActivityLog;
 import sorisoop.soridam.domain.activitylog.domain.ActivityLogRepository;
 import sorisoop.soridam.domain.activitylog.domain.enums.ActivityType;
 import sorisoop.soridam.domain.place.place.domain.Place;
+import sorisoop.soridam.domain.review.domain.ReviewTag;
 import sorisoop.soridam.domain.user.user.domain.User;
 
 @Service
@@ -18,14 +21,11 @@ public class ActivityLogService {
 
 	@Async("activityLogExecutor")
 	public void save(User user, Place place, ActivityType activityType) {
-		if (user == null || place == null || activityType == null) return;
+		if (validateAndLogInput(user, place, activityType)) return;
 
-		Point location = place.getLocation();
-
-		if (location == null) return;
-
-		double lon = location.getX();
-		double lat = location.getY();
+		double[] coords = extractCoordinates(place);
+		double lon = coords[0];
+		double lat = coords[1];
 
 		ActivityLog activityLog = ActivityLog.create(
 			user.getId(),
@@ -37,5 +37,36 @@ public class ActivityLogService {
 		);
 
 		activityLogRepository.save(activityLog);
+	}
+
+	@Async("activityLogExecutor")
+	public void save(User user, Place place, ActivityType activityType, Set<ReviewTag> tags) {
+		if (validateAndLogInput(user, place, activityType)) return;
+
+		double[] coords = extractCoordinates(place);
+		double lon = coords[0];
+		double lat = coords[1];
+
+		ActivityLog activityLog = ActivityLog.create(
+				user.getId(),
+				place.getId(),
+				lat,
+				lon,
+				activityType,
+				activityType.getScore(),
+				tags
+			);
+
+		activityLogRepository.save(activityLog);
+	}
+
+	private boolean validateAndLogInput(User user, Place place, ActivityType activityType) {
+		if (user == null || place == null || activityType == null) return true;
+		return place.getLocation() == null;
+	}
+
+	private double[] extractCoordinates(Place place) {
+		Point location = place.getLocation();
+		return new double[]{location.getX(), location.getY()};
 	}
 }

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/activitylog/application/ActivityLogService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/activitylog/application/ActivityLogService.java
@@ -32,8 +32,7 @@ public class ActivityLogService {
 			place.getId(),
 			lat,
 			lon,
-			activityType,
-			activityType.getScore()
+			activityType
 		);
 
 		activityLogRepository.save(activityLog);
@@ -53,7 +52,6 @@ public class ActivityLogService {
 				lat,
 				lon,
 				activityType,
-				activityType.getScore(),
 				tags
 			);
 

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/activitylog/application/ActivityLogService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/activitylog/application/ActivityLogService.java
@@ -40,7 +40,7 @@ public class ActivityLogService {
 
 	@Async("activityLogExecutor")
 	public void save(User user, Place place, ActivityType activityType, Set<ReviewTag> tags) {
-		if (validateAndLogInput(user, place, activityType)) return;
+		if (isInvalidInput(user, place, activityType)) return;
 
 		double[] coords = extractCoordinates(place);
 		double lon = coords[0];
@@ -58,7 +58,7 @@ public class ActivityLogService {
 		activityLogRepository.save(activityLog);
 	}
 
-	private boolean validateAndLogInput(User user, Place place, ActivityType activityType) {
+	private boolean isInvalidInput(User user, Place place, ActivityType activityType) {
 		if (user == null || place == null || activityType == null) return true;
 		return place.getLocation() == null;
 	}

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/activitylog/domain/ActivityLog.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/activitylog/domain/ActivityLog.java
@@ -1,6 +1,7 @@
 package sorisoop.soridam.domain.activitylog.domain;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
@@ -11,6 +12,7 @@ import org.springframework.data.elasticsearch.core.geo.GeoPoint;
 import lombok.Builder;
 import lombok.Getter;
 import sorisoop.soridam.domain.activitylog.domain.enums.ActivityType;
+import sorisoop.soridam.domain.review.domain.ReviewTag;
 
 @Getter
 @Builder
@@ -36,6 +38,9 @@ public class ActivityLog {
 	@Field(type = FieldType.Date)
 	private final LocalDateTime createdAt;
 
+	@Field(type = FieldType.Keyword)
+	private final Set<ReviewTag> reviewTag;
+
 	public Double getScore() {
 		return customScore != null ? customScore : activityType.getScore();
 	}
@@ -49,6 +54,19 @@ public class ActivityLog {
 			.activityType(activityType)
 			.customScore(customScore)
 			.createdAt(LocalDateTime.now())
+			.build();
+	}
+
+	public static ActivityLog create(Long userId, Long placeId, double lat, double lon,
+		ActivityType activityType, Double customScore, Set<ReviewTag> reviewTag) {
+		return ActivityLog.builder()
+			.userId(userId)
+			.placeId(placeId)
+			.latlon(new GeoPoint(lat, lon))
+			.activityType(activityType)
+			.customScore(customScore)
+			.createdAt(LocalDateTime.now())
+			.reviewTag(reviewTag)
 			.build();
 	}
 }

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/activitylog/domain/ActivityLog.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/activitylog/domain/ActivityLog.java
@@ -1,5 +1,7 @@
 package sorisoop.soridam.domain.activitylog.domain;
 
+import static lombok.AccessLevel.PROTECTED;
+
 import java.time.LocalDateTime;
 import java.util.Set;
 
@@ -9,13 +11,17 @@ import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 import org.springframework.data.elasticsearch.core.geo.GeoPoint;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import sorisoop.soridam.domain.activitylog.domain.enums.ActivityType;
 import sorisoop.soridam.domain.review.domain.ReviewTag;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = PROTECTED, force = true)
+@AllArgsConstructor(access = PROTECTED)
 @Document(indexName = "activity_log-#{T(java.time.LocalDate).now().format(T(java.time.format.DateTimeFormatter).ofPattern('yyyy-MM'))}")
 public class ActivityLog {
 	@Id
@@ -32,9 +38,6 @@ public class ActivityLog {
 	@Field(type = FieldType.Keyword)
 	private final ActivityType activityType;
 
-	@Field(type = FieldType.Double)
-	private final Double customScore;
-
 	@Field(type = FieldType.Date)
 	private final LocalDateTime createdAt;
 
@@ -42,29 +45,27 @@ public class ActivityLog {
 	private final Set<ReviewTag> reviewTag;
 
 	public Double getScore() {
-		return customScore != null ? customScore : activityType.getScore();
+		return activityType.getScore();
 	}
 
 	public static ActivityLog create(Long userId, Long placeId, double lat, double lon,
-		ActivityType activityType, Double customScore) {
+		ActivityType activityType) {
 		return ActivityLog.builder()
 			.userId(userId)
 			.placeId(placeId)
 			.latlon(new GeoPoint(lat, lon))
 			.activityType(activityType)
-			.customScore(customScore)
 			.createdAt(LocalDateTime.now())
 			.build();
 	}
 
 	public static ActivityLog create(Long userId, Long placeId, double lat, double lon,
-		ActivityType activityType, Double customScore, Set<ReviewTag> reviewTag) {
+		ActivityType activityType, Set<ReviewTag> reviewTag) {
 		return ActivityLog.builder()
 			.userId(userId)
 			.placeId(placeId)
 			.latlon(new GeoPoint(lat, lon))
 			.activityType(activityType)
-			.customScore(customScore)
 			.createdAt(LocalDateTime.now())
 			.reviewTag(reviewTag)
 			.build();

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/common/BaseTimeEntity.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/common/BaseTimeEntity.java
@@ -22,6 +22,5 @@ public abstract class BaseTimeEntity {
 	@UpdateTimestamp
 	protected LocalDateTime updatedAt;
 
-
 	protected LocalDateTime deletedAt;
 }

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/place/place/application/PlaceQueryService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/place/place/application/PlaceQueryService.java
@@ -10,6 +10,7 @@ import sorisoop.soridam.domain.place.place.domain.Place;
 import sorisoop.soridam.domain.place.place.domain.PlaceRepository;
 import sorisoop.soridam.domain.place.place.domain.enums.Category;
 import sorisoop.soridam.domain.place.place.exception.PlaceNotFoundException;
+import sorisoop.soridam.domain.user.user.domain.User;
 import sorisoop.soridam.globalutil.geometry.GeometryUtils;
 
 @Service
@@ -31,5 +32,10 @@ public class PlaceQueryService {
 	public List<Place> getNearPlacesByPoint(double x, double y, int distanceMeter, List<Category> categories) {
 		Point point = geometryUtils.createPoint(x, y);
 		return placeRepository.findNearPlacesByPoint(point, distanceMeter, categories);
+	}
+
+	public List<Place> getRecommendedPlaces(double x, double y, User user) {
+		Point point = geometryUtils.createPoint(x, y);
+		return List.of();
 	}
 }

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/place/place/application/PlaceQueryService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/place/place/application/PlaceQueryService.java
@@ -10,7 +10,6 @@ import sorisoop.soridam.domain.place.place.domain.Place;
 import sorisoop.soridam.domain.place.place.domain.PlaceRepository;
 import sorisoop.soridam.domain.place.place.domain.enums.Category;
 import sorisoop.soridam.domain.place.place.exception.PlaceNotFoundException;
-import sorisoop.soridam.domain.user.user.domain.User;
 import sorisoop.soridam.globalutil.geometry.GeometryUtils;
 
 @Service
@@ -34,8 +33,7 @@ public class PlaceQueryService {
 		return placeRepository.findNearPlacesByPoint(point, distanceMeter, categories);
 	}
 
-	public List<Place> getRecommendedPlaces(double x, double y, User user) {
-		Point point = geometryUtils.createPoint(x, y);
-		return List.of();
+	public List<Place> getAllById(List<Long> recommendPlacesIdsForUser) {
+		return placeRepository.findAllById(recommendPlacesIdsForUser);
 	}
 }

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/place/place/application/PlaceRecommendationService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/place/place/application/PlaceRecommendationService.java
@@ -1,0 +1,16 @@
+package sorisoop.soridam.domain.place.place.application;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import sorisoop.soridam.domain.place.place.domain.PlaceEsQueryPort;
+import sorisoop.soridam.domain.place.place.domain.PlaceRepository;
+import sorisoop.soridam.globalutil.geometry.GeometryUtils;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceRecommendationService {
+	private final PlaceEsQueryPort placeEsQueryPort;
+	private final PlaceRepository placeRepository;
+	private final GeometryUtils geometryUtils;
+}

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/place/place/application/PlaceRecommendationService.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/place/place/application/PlaceRecommendationService.java
@@ -1,16 +1,47 @@
 package sorisoop.soridam.domain.place.place.application;
 
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import sorisoop.soridam.domain.place.place.domain.PlaceEsQueryPort;
-import sorisoop.soridam.domain.place.place.domain.PlaceRepository;
-import sorisoop.soridam.globalutil.geometry.GeometryUtils;
 
 @Service
 @RequiredArgsConstructor
 public class PlaceRecommendationService {
 	private final PlaceEsQueryPort placeEsQueryPort;
-	private final PlaceRepository placeRepository;
-	private final GeometryUtils geometryUtils;
+
+	public List<Long> recommendPlacesForUser(Long userId, double userCurrentLat, double userCurrentLon, int size) throws
+		IOException {
+
+		List<Long> recentPlaceId = placeEsQueryPort.getMyRecentPlaceIds(userId);
+		if (recentPlaceId.isEmpty()) {
+			return List.of();
+		}
+
+		List<Long> similarUserIds = placeEsQueryPort.getSimilarUserIds(recentPlaceId, userId);
+		if (similarUserIds.isEmpty()) {
+			return List.of();
+		}
+
+		Map<Long, Double> scoredPlaces = placeEsQueryPort.getRecommendedPlaces(
+			similarUserIds,
+			recentPlaceId,
+			userCurrentLat,
+			userCurrentLon
+		);
+		if (scoredPlaces.isEmpty()) {
+			return List.of();
+		}
+
+		return scoredPlaces.entrySet().stream()
+			.sorted(Map.Entry.<Long, Double>comparingByValue(Comparator.reverseOrder()))
+			.limit(size)
+			.map(Map.Entry::getKey)
+			.toList();
+	}
 }

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/place/place/domain/PlaceEsQueryPort.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/place/place/domain/PlaceEsQueryPort.java
@@ -7,6 +7,6 @@ import java.util.Map;
 public interface PlaceEsQueryPort {
 	List<Long> getMyRecentPlaceIds(Long userId) throws IOException;
 	List<Long> getSimilarUserIds(List<Long> placeIds, Long userId) throws IOException;
-	Map<Long, Double> getRecommendedPlaces(List<Long> similarUserIds, List<Long> excludePlaceIds) throws IOException;
+	Map<Long, Double> getRecommendedPlaces(List<Long> similarUserIds, List<Long> excludePlaceIds, double userCurrentLat, double userCurrentLon) throws IOException;
 }
 

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/place/place/domain/PlaceEsQueryPort.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/place/place/domain/PlaceEsQueryPort.java
@@ -1,0 +1,12 @@
+package sorisoop.soridam.domain.place.place.domain;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public interface PlaceEsQueryPort {
+	List<Long> getMyRecentPlaceIds(Long userId) throws IOException;
+	List<Long> getSimilarUserIds(List<Long> placeIds, Long userId) throws IOException;
+	Map<Long, Double> getRecommendedPlaces(List<Long> similarUserIds, List<Long> excludePlaceIds) throws IOException;
+}
+

--- a/soridam-domain/src/main/java/sorisoop/soridam/domain/place/place/domain/PlaceRepository.java
+++ b/soridam-domain/src/main/java/sorisoop/soridam/domain/place/place/domain/PlaceRepository.java
@@ -27,4 +27,6 @@ public interface PlaceRepository {
 	void saveAll(List<PlaceInsertDto> places);
 
 	void saveAllDocuments(List<PlaceDocument> placeDocuments);
+
+	List<Place> findAllById(List<Long> ids);
 }

--- a/soridam-infra/build.gradle
+++ b/soridam-infra/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 
     // elasticsearch
     implementation("org.springframework.boot:spring-boot-starter-data-elasticsearch")
-    implementation("co.elastic.clients:elasticsearch-java:9.0.3")
+    implementation("co.elastic.clients:elasticsearch-java:8.18.1")
 
     implementation 'org.postgresql:postgresql'
 }

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/config/data/es/ElasticsearchConfig.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/config/data/es/ElasticsearchConfig.java
@@ -1,10 +1,27 @@
 package sorisoop.soridam.infra.config.data.es;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import lombok.RequiredArgsConstructor;
+
 @Configuration
+@RequiredArgsConstructor
 @EnableElasticsearchRepositories(basePackages = "sorisoop.soridam.infra.repository.es")
 public class ElasticsearchConfig {
+	private final ElasticsearchProperties elasticsearchProperties;
+
+	@Bean
+	public ElasticsearchClient elasticsearchClient() {
+		return ElasticsearchClient.of(b -> b
+			.host(elasticsearchProperties.getUris())
+			.usernameAndPassword(
+				elasticsearchProperties.getUsername(),
+				elasticsearchProperties.getPassword()
+			)
+		);
+	}
 }
 

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/config/data/es/ElasticsearchConfig.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/config/data/es/ElasticsearchConfig.java
@@ -6,11 +6,12 @@ import org.springframework.data.elasticsearch.repository.config.EnableElasticsea
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import lombok.RequiredArgsConstructor;
+import sorisoop.soridam.infra.config.base.SoriDamConfig;
 
 @Configuration
 @RequiredArgsConstructor
 @EnableElasticsearchRepositories(basePackages = "sorisoop.soridam.infra.repository.es")
-public class ElasticsearchConfig {
+public class ElasticsearchConfig implements SoriDamConfig {
 	private final ElasticsearchProperties elasticsearchProperties;
 
 	@Bean

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/config/data/es/ElasticsearchConfig.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/config/data/es/ElasticsearchConfig.java
@@ -1,10 +1,20 @@
 package sorisoop.soridam.infra.config.data.es;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.apache.http.Header;
+import org.apache.http.HttpHost;
+import org.apache.http.message.BasicHeader;
+import org.elasticsearch.client.RestClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
 import lombok.RequiredArgsConstructor;
 import sorisoop.soridam.infra.config.base.SoriDamConfig;
 
@@ -16,13 +26,28 @@ public class ElasticsearchConfig implements SoriDamConfig {
 
 	@Bean
 	public ElasticsearchClient elasticsearchClient() {
-		return ElasticsearchClient.of(b -> b
-			.host(elasticsearchProperties.getUris())
-			.usernameAndPassword(
-				elasticsearchProperties.getUsername(),
-				elasticsearchProperties.getPassword()
+		RestClient restClient = RestClient.builder(
+				HttpHost.create(elasticsearchProperties.getUris())
 			)
+			.setDefaultHeaders(new Header[] {
+				new BasicHeader("Authorization", basicAuth(
+					elasticsearchProperties.getUsername(),
+					elasticsearchProperties.getPassword()
+				))
+			})
+			.build();
+
+		ElasticsearchTransport transport = new RestClientTransport(
+			restClient, new JacksonJsonpMapper()
 		);
+
+		return new ElasticsearchClient(transport);
 	}
+
+	private String basicAuth(String username, String password) {
+		String auth = username + ":" + password;
+		return "Basic " + Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
+	}
+
 }
 

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/config/data/es/ElasticsearchProperties.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/config/data/es/ElasticsearchProperties.java
@@ -1,5 +1,6 @@
 package sorisoop.soridam.infra.config.data.es;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 import lombok.AllArgsConstructor;
@@ -12,7 +13,7 @@ import lombok.Setter;
 @Component
 @NoArgsConstructor
 @AllArgsConstructor
-//@ConfigurationProperties(prefix = "spring.elasticsearch")
+@ConfigurationProperties(prefix = "spring.elasticsearch")
 public class ElasticsearchProperties {
 	private String uris;
 	private String username;

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/config/data/es/ElasticsearchProperties.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/config/data/es/ElasticsearchProperties.java
@@ -1,0 +1,21 @@
+package sorisoop.soridam.infra.config.data.es;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Component
+@NoArgsConstructor
+@AllArgsConstructor
+@ConfigurationProperties(prefix = "spring.elasticsearch")
+public class ElasticsearchProperties {
+	private String uris;
+	private String username;
+	private String password;
+}

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/config/data/es/ElasticsearchProperties.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/config/data/es/ElasticsearchProperties.java
@@ -1,6 +1,5 @@
 package sorisoop.soridam.infra.config.data.es;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 import lombok.AllArgsConstructor;
@@ -13,7 +12,7 @@ import lombok.Setter;
 @Component
 @NoArgsConstructor
 @AllArgsConstructor
-@ConfigurationProperties(prefix = "spring.elasticsearch")
+//@ConfigurationProperties(prefix = "spring.elasticsearch")
 public class ElasticsearchProperties {
 	private String uris;
 	private String username;

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/es/PlaceEsQueryClient.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/es/PlaceEsQueryClient.java
@@ -64,6 +64,7 @@ public class PlaceEsQueryClient implements PlaceEsQueryPort {
 								.field("placeId")
 								.terms(tq -> tq.value(
 									placeIds.stream()
+										.filter(Objects::nonNull)
 										.map(FieldValue::of)
 										.toList()
 								))
@@ -87,7 +88,7 @@ public class PlaceEsQueryClient implements PlaceEsQueryPort {
 		return response.hits().hits().stream()
 			.map(Hit::source)
 			.filter(Objects::nonNull)
-			.map(ActivityLog::getPlaceId)
+			.map(ActivityLog::getUserId)
 			.distinct()
 			.toList();
 	}
@@ -106,6 +107,7 @@ public class PlaceEsQueryClient implements PlaceEsQueryPort {
 											.field("userId")
 											.terms(tq -> tq.value(
 												similarUserIds.stream()
+													.filter(Objects::nonNull)
 													.map(FieldValue::of)
 													.toList()
 											))
@@ -116,6 +118,7 @@ public class PlaceEsQueryClient implements PlaceEsQueryPort {
 											.field("placeId")
 											.terms(tq -> tq.value(
 												excludePlaceIds.stream()
+													.filter(Objects::nonNull)
 													.map(FieldValue::of)
 													.toList()
 											))
@@ -128,7 +131,7 @@ public class PlaceEsQueryClient implements PlaceEsQueryPort {
 											.lat(userCurrentLat)
 											.lon(userCurrentLon)
 										))
-										.distance("20km")
+										.distance("10km")
 									)
 								)
 							)
@@ -155,7 +158,7 @@ public class PlaceEsQueryClient implements PlaceEsQueryPort {
 						.boostMode(FunctionBoostMode.Multiply)
 					)
 				)
-				.size(10000)
+				.size(100)
 				.source(SourceConfig.of(sc -> sc
 					.filter(sf -> sf.includes("placeId", "activityType", "reviewTags", "latlon"))
 				)),

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/es/PlaceEsQueryClient.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/es/PlaceEsQueryClient.java
@@ -85,7 +85,9 @@ public class PlaceEsQueryClient implements PlaceEsQueryPort {
 		);
 
 		return response.hits().hits().stream()
-			.map(hit -> hit.source().getUserId())
+			.map(Hit::source)
+			.filter(Objects::nonNull)
+			.map(ActivityLog::getPlaceId)
 			.distinct()
 			.toList();
 	}

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/es/PlaceEsQueryClient.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/es/PlaceEsQueryClient.java
@@ -3,6 +3,7 @@ package sorisoop.soridam.infra.repository.es;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
@@ -46,10 +47,9 @@ public class PlaceEsQueryClient implements PlaceEsQueryPort {
 		);
 
 		return response.hits().hits().stream()
-			.map(hit -> {
-				assert hit.source() != null;
-				return hit.source().getPlaceId();
-			})
+			.map(Hit::source)
+			.filter(Objects::nonNull)
+			.map(ActivityLog::getPlaceId)
 			.toList();
 	}
 

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/es/PlaceEsQueryClient.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/es/PlaceEsQueryClient.java
@@ -119,6 +119,16 @@ public class PlaceEsQueryClient implements PlaceEsQueryPort {
 											))
 										)
 									)
+								.filter(f -> f
+									.geoDistance(gd -> gd
+										.field("latlon")
+										.location(l -> l.latlon(ll -> ll
+											.lat(userCurrentLat)
+											.lon(userCurrentLon)
+										))
+										.distance("20km")
+									)
+								)
 							)
 						)
 						.functions(f -> f

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/es/PlaceEsQueryClient.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/es/PlaceEsQueryClient.java
@@ -145,7 +145,7 @@ public class PlaceEsQueryClient implements PlaceEsQueryPort {
 				)
 				.size(10000)
 				.source(SourceConfig.of(sc -> sc
-					.filter(sf -> sf.includes("placeId", "customScore", "activityType", "reviewTags", "latlon"))
+					.filter(sf -> sf.includes("placeId", "activityType", "reviewTags", "latlon"))
 				)),
 			ActivityLog.class
 		);

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/es/PlaceEsQueryClient.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/es/PlaceEsQueryClient.java
@@ -1,0 +1,132 @@
+package sorisoop.soridam.infra.repository.es;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.SortOptions;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.core.search.SourceConfig;
+import lombok.RequiredArgsConstructor;
+import sorisoop.soridam.domain.activitylog.domain.ActivityLog;
+import sorisoop.soridam.domain.place.place.domain.PlaceEsQueryPort;
+
+@Component
+@RequiredArgsConstructor
+public class PlaceEsQueryClient implements PlaceEsQueryPort {
+	private final ElasticsearchClient elasticsearchClient;
+
+	@Override
+	public List<Long> getMyRecentPlaceIds(Long userId) throws IOException {
+		SearchResponse<ActivityLog> response = elasticsearchClient.search(s -> s
+				.index("activity_log-*")
+				.query(Query.of(q -> q
+					.term(t -> t.field("userId").value(userId))
+				))
+				.sort(SortOptions.of(so -> so
+					.field(f -> f.field("createdAt").order(SortOrder.Desc))
+				))
+				.size(200)
+				.source(SourceConfig.of(sc -> sc
+					.filter(sf -> sf.includes("placeId"))
+				)),
+			ActivityLog.class
+		);
+
+		return response.hits().hits().stream()
+			.map(hit -> {
+				assert hit.source() != null;
+				return hit.source().getPlaceId();
+			})
+			.toList();
+	}
+
+	@Override
+	public List<Long> getSimilarUserIds(List<Long> placeIds, Long userId) throws IOException {
+		SearchResponse<ActivityLog> response = elasticsearchClient.search(s -> s
+				.index("activity_log-*")
+				.query(q -> q
+					.bool(b -> b
+						.must(m -> m
+							.terms(t -> t
+								.field("placeId")
+								.terms(tq -> tq.value(
+									placeIds.stream()
+										.map(FieldValue::of)
+										.toList()
+								))
+							)
+						)
+						.mustNot(mn -> mn
+							.term(t -> t
+								.field("userId")
+								.value(userId)
+							)
+						)
+					)
+				)
+				.size(500)
+				.source(SourceConfig.of(sc -> sc
+					.filter(sf -> sf.includes("userId"))
+				)),
+			ActivityLog.class
+		);
+
+		return response.hits().hits().stream()
+			.map(hit -> hit.source().getUserId())
+			.distinct()
+			.toList();
+	}
+
+	@Override
+	public Map<Long, Double> getRecommendedPlaces(List<Long> similarUserIds, List<Long> excludePlaceIds) throws
+		IOException {
+		SearchResponse<ActivityLog> response = elasticsearchClient.search(s -> s
+				.index("activity_log-*")
+				.query(q -> q
+					.bool(b -> b
+						.must(m -> m
+							.terms(t -> t
+								.field("userId")
+								.terms(tq -> tq.value(
+									similarUserIds.stream()
+										.map(FieldValue::of)
+										.toList()
+								))
+							)
+						)
+						.mustNot(mn -> mn
+							.terms(t -> t
+								.field("placeId")
+								.terms(tq -> tq.value(
+									excludePlaceIds.stream()
+										.map(FieldValue::of)
+										.toList()
+								))
+							)
+						)
+					)
+				)
+				.size(1000)
+				.source(SourceConfig.of(sc -> sc
+					.filter(sf -> sf.includes("placeId", "customScore", "activityType"))
+				)),
+			ActivityLog.class
+		);
+
+		return response.hits().hits().stream()
+			.map(Hit::source)
+			.collect(Collectors.groupingBy(
+				activityLog -> activityLog != null ? activityLog.getPlaceId() : null,
+				Collectors.summingDouble(ActivityLog::getScore)
+			));
+	}
+}

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/es/PlaceEsQueryClient.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/es/PlaceEsQueryClient.java
@@ -9,8 +9,11 @@ import org.springframework.stereotype.Component;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.GeoLocation;
 import co.elastic.clients.elasticsearch._types.SortOptions;
 import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.query_dsl.FunctionBoostMode;
+import co.elastic.clients.elasticsearch._types.query_dsl.MultiValueMode;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
@@ -18,6 +21,7 @@ import co.elastic.clients.elasticsearch.core.search.SourceConfig;
 import lombok.RequiredArgsConstructor;
 import sorisoop.soridam.domain.activitylog.domain.ActivityLog;
 import sorisoop.soridam.domain.place.place.domain.PlaceEsQueryPort;
+
 
 @Component
 @RequiredArgsConstructor
@@ -87,45 +91,70 @@ public class PlaceEsQueryClient implements PlaceEsQueryPort {
 	}
 
 	@Override
-	public Map<Long, Double> getRecommendedPlaces(List<Long> similarUserIds, List<Long> excludePlaceIds) throws
-		IOException {
+	public Map<Long, Double> getRecommendedPlaces(List<Long> similarUserIds, List<Long> excludePlaceIds,
+		double userCurrentLat, double userCurrentLon) throws IOException {
 		SearchResponse<ActivityLog> response = elasticsearchClient.search(s -> s
 				.index("activity_log-*")
 				.query(q -> q
-					.bool(b -> b
-						.must(m -> m
-							.terms(t -> t
-								.field("userId")
-								.terms(tq -> tq.value(
-									similarUserIds.stream()
-										.map(FieldValue::of)
-										.toList()
-								))
+					.functionScore(fs -> fs
+						.query(innerQuery -> innerQuery
+							.bool(b -> b
+									.must(m -> m
+										.terms(t -> t
+											.field("userId")
+											.terms(tq -> tq.value(
+												similarUserIds.stream()
+													.map(FieldValue::of)
+													.toList()
+											))
+										)
+									)
+									.mustNot(mn -> mn
+										.terms(t -> t
+											.field("placeId")
+											.terms(tq -> tq.value(
+												excludePlaceIds.stream()
+													.map(FieldValue::of)
+													.toList()
+											))
+										)
+									)
 							)
 						)
-						.mustNot(mn -> mn
-							.terms(t -> t
-								.field("placeId")
-								.terms(tq -> tq.value(
-									excludePlaceIds.stream()
-										.map(FieldValue::of)
-										.toList()
-								))
+						.functions(f -> f
+							.gauss(g -> g
+								.geo(geo -> geo
+									.field("latlon")
+									.placement(p -> {
+										GeoLocation userLocation = GeoLocation.of(o -> o.latlon(ll -> ll
+											.lat(userCurrentLat)
+											.lon(userCurrentLon)
+										));
+										return p
+											.origin(userLocation)
+											.scale("1km")
+											.offset("0km")
+											.decay(0.5);
+									})
+									.multiValueMode(MultiValueMode.Avg)
+								)
 							)
 						)
+						.boostMode(FunctionBoostMode.Multiply)
 					)
 				)
-				.size(1000)
+				.size(10000)
 				.source(SourceConfig.of(sc -> sc
-					.filter(sf -> sf.includes("placeId", "customScore", "activityType"))
+					.filter(sf -> sf.includes("placeId", "customScore", "activityType", "reviewTags", "latlon"))
 				)),
 			ActivityLog.class
 		);
 
 		return response.hits().hits().stream()
 			.map(Hit::source)
+			.filter(java.util.Objects::nonNull)
 			.collect(Collectors.groupingBy(
-				activityLog -> activityLog != null ? activityLog.getPlaceId() : null,
+				ActivityLog::getPlaceId,
 				Collectors.summingDouble(ActivityLog::getScore)
 			));
 	}

--- a/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/impl/PlaceRepositoryImpl.java
+++ b/soridam-infra/src/main/java/sorisoop/soridam/infra/repository/impl/PlaceRepositoryImpl.java
@@ -69,4 +69,9 @@ public class PlaceRepositoryImpl implements PlaceRepository {
 	public void saveAllDocuments(List<PlaceDocument> placeDocuments) {
 		documentPlaceRepository.saveAll(placeDocuments);
 	}
+
+	@Override
+	public List<Place> findAllById(List<Long> ids) {
+		return jpaPlaceRepository.findAllById(ids);
+	}
 }


### PR DESCRIPTION
## Summary

>- close #152 

**유사 사용자 및 위치 기반 추천 기능 추가**

## Tasks

- 유사 사용자의 활동 로그를 기반으로 추천 장소 후보를 조회하는 로직 구현
- Function Score + Gauss Decay + Geo 필터를 활용하여 사용자 현재 위치 중심 추천 점수 계산
- 활동 로그에서 기존 사용자가 방문한 장소는 추천에서 제외
- 추천 결과를 점수 기준으로 정렬 및 제한된 개수 반환
- Elasticsearch 오류 및 매핑 누락 케이스 대응


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자의 활동 기반으로 장소 추천을 제공하는 새로운 추천 API 엔드포인트가 추가되었습니다. 위치 정보(위도, 경도)와 원하는 결과 수를 전달하면 맞춤 장소 리스트를 받아볼 수 있습니다.

* **버그 수정**
  * 리뷰 작성 시 활동 로그에 리뷰 태그 정보가 함께 기록되도록 개선되었습니다.

* **시스템 및 인프라**
  * Elasticsearch 연동이 공식 클라이언트와 인증 설정을 통해 안정적으로 구성되었습니다.
  * Elasticsearch 클라이언트 라이브러리 버전이 하향 조정되었습니다(9.0.3 → 8.18.1).

* **리팩터링**
  * 활동 로그 저장 로직이 모듈화되어 입력 검증 및 좌표 추출이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->